### PR TITLE
Add support for mixed case column names in PostgreSQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,11 @@ subprojects { project ->
                             name = "afezeria"
                             email = "zodal@outlook.com"
                         }
+                        developer {
+                            id = "lyndsysimon"
+                            name = "Lyndsy Simon
+                            email = "lyndsy@lyndsysimon.com"
+                        }
                     }
                     scm {
                         url = "https://github.com/vincentlauvlwj/Ktorm.git"

--- a/ktorm-core/src/main/kotlin/me/liuwj/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/me/liuwj/ktorm/expression/SqlFormatter.kt
@@ -73,7 +73,7 @@ open class SqlFormatter(
         }
     }
 
-    protected val String.quoted: String get() {
+    open protected val String.quoted: String get() {
         if (this.toUpperCase() in database.keywords || !this.isIdentifier) {
             return "${database.identifierQuoteString}${this}${database.identifierQuoteString}".trim()
         } else {

--- a/ktorm-core/src/test/kotlin/me/liuwj/ktorm/BaseTest.kt
+++ b/ktorm-core/src/test/kotlin/me/liuwj/ktorm/BaseTest.kt
@@ -58,6 +58,7 @@ open class BaseTest {
         val id: Int
         var name: String
         var location: LocationWrapper
+        var mixedCase: String?
     }
 
     interface Employee : Entity<Employee> {
@@ -78,6 +79,7 @@ open class BaseTest {
         val id = int("id").primaryKey().bindTo { it.id }
         val name = varchar("name").bindTo { it.name }
         val location = varchar("location").transform({ LocationWrapper(it) }, { it.underlying }).bindTo { it.location }
+        val mixedCase = varchar("mixedCase").bindTo { it.mixedCase }
     }
 
     open class Employees(alias: String?) : Table<Employee>("t_employee", alias) {

--- a/ktorm-core/src/test/resources/init-data.sql
+++ b/ktorm-core/src/test/resources/init-data.sql
@@ -2,7 +2,8 @@
 create table t_department(
   id int not null primary key auto_increment,
   name varchar(128) not null,
-  location varchar(128) not null
+  location varchar(128) not null,
+  mixedCase varchar(128)
 );
 
 create table t_employee(

--- a/ktorm-support-mysql/src/test/resources/init-mysql-data.sql
+++ b/ktorm-support-mysql/src/test/resources/init-mysql-data.sql
@@ -2,7 +2,8 @@
 create table t_department(
   id int not null primary key auto_increment,
   name varchar(128) not null,
-  location varchar(128) not null
+  location varchar(128) not null,
+  mixedCase varchar(128)
 );
 
 create table t_employee(

--- a/ktorm-support-postgresql/src/main/kotlin/me/liuwj/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/me/liuwj/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -47,6 +47,10 @@ open class PostgreSqlFormatter(database: Database, beautifySql: Boolean, indentS
         return result
     }
 
+    override val String.quoted: String get() {
+        return "${database.identifierQuoteString}${this}${database.identifierQuoteString}".trim()
+    }
+
     override fun <T : Any> visitScalar(expr: ScalarExpression<T>): ScalarExpression<T> {
         val result = when (expr) {
             is ILikeExpression -> visitILike(expr)

--- a/ktorm-support-postgresql/src/test/kotlin/me/liuwj/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/me/liuwj/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -138,6 +138,7 @@ class PostgreSqlTest : BaseTest() {
             return database.insert(Departments) {
                 it.name to "dept name"
                 it.location to LocationWrapper("dept location")
+                it.mixedCase to "value for mixed case"
             }
         }
     }

--- a/ktorm-support-postgresql/src/test/resources/init-postgresql-data.sql
+++ b/ktorm-support-postgresql/src/test/resources/init-postgresql-data.sql
@@ -3,7 +3,8 @@ create extension if not exists hstore;
 create table t_department(
   id serial primary key,
   name varchar(128) not null,
-  location varchar(128) not null
+  location varchar(128) not null,
+  "mixedCase" varchar(123)
 );
 
 create table t_employee(
@@ -22,8 +23,8 @@ create table t_metadata(
   numbers text[] not null
 );
 
-insert into t_department(name, location) values ('tech', 'Guangzhou');
-insert into t_department(name, location) values ('finance', 'Beijing');
+insert into t_department(name, location, "mixedCase") values ('tech', 'Guangzhou', 'one');
+insert into t_department(name, location, "mixedCase") values ('finance', 'Beijing', 'two');
 
 insert into t_employee(name, job, manager_id, hire_date, salary, department_id)
 values ('vince', 'engineer', null, '2018-01-01', 100, 1);

--- a/ktorm-support-sqlite/src/test/resources/init-sqlite-data.sql
+++ b/ktorm-support-sqlite/src/test/resources/init-sqlite-data.sql
@@ -2,7 +2,8 @@
 create table t_department(
   id integer primary key autoincrement,
   name text not null,
-  location text not null
+  location text not null,
+  mixedCase text
 );
 
 create table t_employee(


### PR DESCRIPTION
I'm building a small service using an existing PostgreSQL database, and came across a bug where column names defined with mixed case (e.g. "columnName") did not generate the correct SQL for PostgreSQL - the column names were not quoted.

PostgreSQL transforms unquoted column names to their lowercase equivalent: `columnName` becomes `columnname`, which is not defined as a column.

I resolved this by quoting all column names in the PostgreSQL dialect. To do this, I had to open the implementation of `String.quoted` in `SqlDialect`. I could have done it by overriding `PostgreSqlDialect.visitColumn` and `PostgreSqlDialect.visitInsert`, but that seemed both unnecessarily verbose and duplicated much of the logic from the parent class.

Note that I am very new to Kotlin, so please take care to ensure that my changes are appropriate.