### PR TITLE
Support postgresql text[] columns containing null values

### DIFF
--- a/ktorm-support-postgresql/src/main/kotlin/me/liuwj/ktorm/support/postgresql/SqlTypes.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/me/liuwj/ktorm/support/postgresql/SqlTypes.kt
@@ -71,9 +71,9 @@ object TextArraySqlType : SqlType<TextArray>(Types.ARRAY, "text[]") {
 
     @Suppress("UNCHECKED_CAST")
     override fun doGetResult(rs: ResultSet, index: Int): TextArray? {
-        val sqlArray = rs.getArray(index)
+        val sqlArray = rs.getArray(index) ?: return null
         try {
-            val objectArray = sqlArray?.array as Array<Any?>?
+            val objectArray = sqlArray.array as Array<Any?>?
             return objectArray?.map { it as String? }?.toTypedArray()
         } finally {
             sqlArray.free()

--- a/ktorm-support-postgresql/src/test/kotlin/me/liuwj/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/me/liuwj/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -158,6 +158,17 @@ class PostgreSqlTest : BaseTest() {
     }
 
     @Test
+    fun testHStoreIsNull() {
+        database.update(Metadatas) {
+            it.attributes to null
+            where { it.id eq 1 }
+        }
+
+        val attributes = get { it.attributes }
+        assertThat(attributes, nullValue())
+    }
+
+    @Test
     fun testHStoreGetValue() {
         assert(get { it.attributes["a"] } == "1")
         assert(get { it.attributes["b"] } == "2")
@@ -278,5 +289,16 @@ class PostgreSqlTest : BaseTest() {
 
         val numbers = get { it.numbers } ?: error("Cannot get the numbers!")
         assertThat(numbers, equalTo(arrayOf<String?>("a", "b")))
+    }
+
+    @Test
+    fun testTextArrayIsNull() {
+        database.update(Metadatas) {
+            it.numbers to null
+            where { it.id eq 1 }
+        }
+
+        val numbers = get { it.numbers }
+        assertThat(numbers, nullValue())
     }
 }

--- a/ktorm-support-postgresql/src/test/resources/init-postgresql-data.sql
+++ b/ktorm-support-postgresql/src/test/resources/init-postgresql-data.sql
@@ -18,8 +18,8 @@ create table t_employee(
 
 create table t_metadata(
   id serial primary key,
-  attrs hstore not null,
-  numbers text[] not null
+  attrs hstore,
+  numbers text[]
 );
 
 insert into t_department(name, location) values ('tech', 'Guangzhou');


### PR DESCRIPTION
I discovered today that PostgreSQL columns containing null values raised a `java.lang.NullPointerException`.

I found that `me.liuwj.ktorm.support.postgresqlTextArraySqlType.doGetResult` was not returning early if `ResultSet.getArray` returned null, which later resulted in the above exception when attempting to free the variable to which it was assigned.

I added the early return, modeling it on the implementation of `BlobSqlType`, and added a tests for `text[]` and `store` columns containing null values.