### PR TITLE
Identifier case transform

### DIFF
--- a/ktorm-core/src/main/kotlin/me/liuwj/ktorm/database/Database.kt
+++ b/ktorm-core/src/main/kotlin/me/liuwj/ktorm/database/Database.kt
@@ -143,6 +143,62 @@ class Database(
      */
     lateinit var extraNameCharacters: String private set
 
+    /**
+     * Whether this database threats mixed case unquoted SQL identifiers as case sensitive and as a result
+     * stores them in mixed case.
+     */
+    var supportsMixedCaseIdentifiers: Boolean = false
+        private set
+
+    /**
+     * Whether this database treats mixed case unquoted SQL identifiers as case insensitive and
+     * stores them in mixed case.
+     */
+    var storesMixedCaseIdentifiers: Boolean = false
+        private set
+
+    /**
+     * Whether this database treats mixed case unquoted SQL identifiers as case insensitive and
+     * stores them in upper case.
+     */
+    var storesUpperCaseIdentifiers: Boolean = false
+        private set
+
+    /**
+     * Whether this database treats mixed case unquoted SQL identifiers as case insensitive and
+     * stores them in lower case.
+     */
+    var storesLowerCaseIdentifiers: Boolean = false
+        private set
+
+    /**
+     * Whether this database treats mixed case quoted SQL identifiers as case sensitive and as a result
+     * stores them in mixed case.
+     */
+    var supportsMixedCaseQuotedIdentifiers: Boolean = false
+        private set
+
+    /**
+     * Whether this database treats mixed case quoted SQL identifiers as case insensitive and
+     * stores them in mixed case.
+     */
+    var storesMixedCaseQuotedIdentifiers: Boolean = false
+        private set
+
+    /**
+     * Whether this database treats mixed case quoted SQL identifiers as case insensitive and
+     * stores them in upper case.
+     */
+    var storesUpperCaseQuotedIdentifiers: Boolean = false
+        private set
+
+    /**
+     * Whether this database treats mixed case quoted SQL identifiers as case insensitive and
+     * stores them in lower case.
+     */
+    var storesLowerCaseQuotedIdentifiers: Boolean = false
+        private set
+
     init {
         fun Result<String?>.orEmpty() = getOrNull().orEmpty()
 
@@ -155,6 +211,14 @@ class Database(
             keywords = ANSI_SQL_2003_KEYWORDS + metadata.runCatching { sqlKeywords }.orEmpty().toUpperCase().split(',')
             identifierQuoteString = metadata.runCatching { identifierQuoteString }.orEmpty().trim()
             extraNameCharacters = metadata.runCatching { extraNameCharacters }.orEmpty()
+            supportsMixedCaseIdentifiers = metadata.runCatching { supportsMixedCaseIdentifiers() }.getOrDefault(false)
+            storesMixedCaseIdentifiers = metadata.runCatching { storesMixedCaseIdentifiers() }.getOrDefault(false)
+            storesUpperCaseIdentifiers = metadata.runCatching { storesUpperCaseIdentifiers() }.getOrDefault(false)
+            storesLowerCaseIdentifiers = metadata.runCatching { storesLowerCaseIdentifiers() }.getOrDefault(false)
+            supportsMixedCaseQuotedIdentifiers = metadata.runCatching { supportsMixedCaseQuotedIdentifiers() }.getOrDefault(false)
+            storesMixedCaseQuotedIdentifiers = metadata.runCatching { storesMixedCaseQuotedIdentifiers() }.getOrDefault(false)
+            storesUpperCaseQuotedIdentifiers = metadata.runCatching { storesUpperCaseQuotedIdentifiers() }.getOrDefault(false)
+            storesLowerCaseQuotedIdentifiers = metadata.runCatching { storesLowerCaseQuotedIdentifiers() }.getOrDefault(false)
         }
 
         if (logger.isInfoEnabled()) {

--- a/ktorm-core/src/main/kotlin/me/liuwj/ktorm/database/Database.kt
+++ b/ktorm-core/src/main/kotlin/me/liuwj/ktorm/database/Database.kt
@@ -96,17 +96,35 @@ import javax.sql.DataSource
  *     }
  * ```
  * More details about SQL DSL, see [Query], about sequence APIs, see [EntitySequence].
- *
- * @property transactionManager the transaction manager used to manage connections and transactions.
- * @property dialect the dialect, auto detects an implementation by default using JDK [ServiceLoader] facility.
- * @property logger the logger used to output logs, auto detects an implementation by default.
- * @property exceptionTranslator function used to translate SQL exceptions so as to rethrow them to users.
  */
 class Database(
+
+    /**
+     * The transaction manager used to manage connections and transactions.
+     */
     val transactionManager: TransactionManager,
+
+    /**
+     * The dialect, auto detects an implementation by default using JDK [ServiceLoader] facility.
+     */
     val dialect: SqlDialect = detectDialectImplementation(),
+
+    /**
+     * The logger used to output logs, auto detects an implementation by default.
+     */
     val logger: Logger = detectLoggerImplementation(),
-    val exceptionTranslator: ((SQLException) -> Throwable)? = null
+
+    /**
+     * Function used to translate SQL exceptions so as to rethrow them to users.
+     */
+    val exceptionTranslator: ((SQLException) -> Throwable)? = null,
+
+    /**
+     * Whether we need to always quote SQL identifiers in the generated SQLs.
+     *
+     * @since 3.1.0
+     */
+    val alwaysQuoteIdentifiers: Boolean = false
 ) {
     /**
      * The URL of the connected database.
@@ -201,6 +219,7 @@ class Database(
 
     init {
         fun Result<String?>.orEmpty() = getOrNull().orEmpty()
+        fun Result<Boolean>.orFalse() = getOrDefault(false)
 
         useConnection { conn ->
             val metadata = conn.metaData
@@ -211,14 +230,14 @@ class Database(
             keywords = ANSI_SQL_2003_KEYWORDS + metadata.runCatching { sqlKeywords }.orEmpty().toUpperCase().split(',')
             identifierQuoteString = metadata.runCatching { identifierQuoteString }.orEmpty().trim()
             extraNameCharacters = metadata.runCatching { extraNameCharacters }.orEmpty()
-            supportsMixedCaseIdentifiers = metadata.runCatching { supportsMixedCaseIdentifiers() }.getOrDefault(false)
-            storesMixedCaseIdentifiers = metadata.runCatching { storesMixedCaseIdentifiers() }.getOrDefault(false)
-            storesUpperCaseIdentifiers = metadata.runCatching { storesUpperCaseIdentifiers() }.getOrDefault(false)
-            storesLowerCaseIdentifiers = metadata.runCatching { storesLowerCaseIdentifiers() }.getOrDefault(false)
-            supportsMixedCaseQuotedIdentifiers = metadata.runCatching { supportsMixedCaseQuotedIdentifiers() }.getOrDefault(false)
-            storesMixedCaseQuotedIdentifiers = metadata.runCatching { storesMixedCaseQuotedIdentifiers() }.getOrDefault(false)
-            storesUpperCaseQuotedIdentifiers = metadata.runCatching { storesUpperCaseQuotedIdentifiers() }.getOrDefault(false)
-            storesLowerCaseQuotedIdentifiers = metadata.runCatching { storesLowerCaseQuotedIdentifiers() }.getOrDefault(false)
+            supportsMixedCaseIdentifiers = metadata.runCatching { supportsMixedCaseIdentifiers() }.orFalse()
+            storesMixedCaseIdentifiers = metadata.runCatching { storesMixedCaseIdentifiers() }.orFalse()
+            storesUpperCaseIdentifiers = metadata.runCatching { storesUpperCaseIdentifiers() }.orFalse()
+            storesLowerCaseIdentifiers = metadata.runCatching { storesLowerCaseIdentifiers() }.orFalse()
+            supportsMixedCaseQuotedIdentifiers = metadata.runCatching { supportsMixedCaseQuotedIdentifiers() }.orFalse()
+            storesMixedCaseQuotedIdentifiers = metadata.runCatching { storesMixedCaseQuotedIdentifiers() }.orFalse()
+            storesUpperCaseQuotedIdentifiers = metadata.runCatching { storesUpperCaseQuotedIdentifiers() }.orFalse()
+            storesLowerCaseQuotedIdentifiers = metadata.runCatching { storesLowerCaseQuotedIdentifiers() }.orFalse()
         }
 
         if (logger.isInfoEnabled()) {
@@ -479,15 +498,22 @@ class Database(
          *
          * @param dialect the dialect, auto detects an implementation by default using JDK [ServiceLoader] facility.
          * @param logger logger used to output logs, auto detects an implementation by default.
+         * @param alwaysQuoteIdentifiers whether we need to always quote SQL identifiers in the generated SQLs.
          * @param connector the connector function used to obtain SQL connections.
          * @return the new-created database object.
          */
         fun connect(
             dialect: SqlDialect = detectDialectImplementation(),
             logger: Logger = detectLoggerImplementation(),
+            alwaysQuoteIdentifiers: Boolean = false,
             connector: () -> Connection
         ): Database {
-            return Database(JdbcTransactionManager(connector), dialect, logger)
+            return Database(
+                transactionManager = JdbcTransactionManager(connector),
+                dialect = dialect,
+                logger = logger,
+                alwaysQuoteIdentifiers = alwaysQuoteIdentifiers
+            )
         }
 
         /**
@@ -496,14 +522,21 @@ class Database(
          * @param dataSource the data source used to obtain SQL connections.
          * @param dialect the dialect, auto detects an implementation by default using JDK [ServiceLoader] facility.
          * @param logger logger used to output logs, auto detects an implementation by default.
+         * @param alwaysQuoteIdentifiers whether we need to always quote SQL identifiers in the generated SQLs.
          * @return the new-created database object.
          */
         fun connect(
             dataSource: DataSource,
             dialect: SqlDialect = detectDialectImplementation(),
-            logger: Logger = detectLoggerImplementation()
+            logger: Logger = detectLoggerImplementation(),
+            alwaysQuoteIdentifiers: Boolean = false
         ): Database {
-            return connect(dialect, logger) { dataSource.connection }
+            return Database(
+                transactionManager = JdbcTransactionManager { dataSource.connection },
+                dialect = dialect,
+                logger = logger,
+                alwaysQuoteIdentifiers = alwaysQuoteIdentifiers
+            )
         }
 
         /**
@@ -515,6 +548,7 @@ class Database(
          * @param password the password of the database.
          * @param dialect the dialect, auto detects an implementation by default using JDK [ServiceLoader] facility.
          * @param logger logger used to output logs, auto detects an implementation by default.
+         * @param alwaysQuoteIdentifiers whether we need to always quote SQL identifiers in the generated SQLs.
          * @return the new-created database object.
          */
         fun connect(
@@ -523,13 +557,19 @@ class Database(
             user: String? = null,
             password: String? = null,
             dialect: SqlDialect = detectDialectImplementation(),
-            logger: Logger = detectLoggerImplementation()
+            logger: Logger = detectLoggerImplementation(),
+            alwaysQuoteIdentifiers: Boolean = false
         ): Database {
             if (driver != null && driver.isNotBlank()) {
                 Class.forName(driver)
             }
 
-            return connect(dialect, logger) { DriverManager.getConnection(url, user, password) }
+            return Database(
+                transactionManager = JdbcTransactionManager { DriverManager.getConnection(url, user, password) },
+                dialect = dialect,
+                logger = logger,
+                alwaysQuoteIdentifiers = alwaysQuoteIdentifiers
+            )
         }
 
         /**
@@ -545,16 +585,23 @@ class Database(
          * @param dataSource the data source used to obtain SQL connections.
          * @param dialect the dialect, auto detects an implementation by default using JDK [ServiceLoader] facility.
          * @param logger logger used to output logs, auto detects an implementation by default.
+         * @param alwaysQuoteIdentifiers whether we need to always quote SQL identifiers in the generated SQLs.
          * @return the new-created database object.
          */
         fun connectWithSpringSupport(
             dataSource: DataSource,
             dialect: SqlDialect = detectDialectImplementation(),
-            logger: Logger = detectLoggerImplementation()
+            logger: Logger = detectLoggerImplementation(),
+            alwaysQuoteIdentifiers: Boolean = false
         ): Database {
-            val transactionManager = SpringManagedTransactionManager(dataSource)
-            val exceptionTranslator = SQLErrorCodeSQLExceptionTranslator(dataSource)
-            return Database(transactionManager, dialect, logger) { exceptionTranslator.translate("Ktorm", null, it) }
+            val translator = SQLErrorCodeSQLExceptionTranslator(dataSource)
+            return Database(
+                transactionManager = SpringManagedTransactionManager(dataSource),
+                dialect = dialect,
+                logger = logger,
+                exceptionTranslator = { ex -> translator.translate("Ktorm", null, ex) },
+                alwaysQuoteIdentifiers = alwaysQuoteIdentifiers
+            )
         }
     }
 }

--- a/ktorm-core/src/main/kotlin/me/liuwj/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/me/liuwj/ktorm/expression/SqlFormatter.kt
@@ -77,12 +77,32 @@ open class SqlFormatter(
         val shouldQuote = database.alwaysQuoteIdentifiers
             || !this.isIdentifier
             || this.toUpperCase() in database.keywords
-            || this.isMixedCase && !database.supportsMixedCaseIdentifiers
+            || this.isMixedCase && !database.supportsMixedCaseIdentifiers && database.supportsMixedCaseQuotedIdentifiers
 
         if (shouldQuote) {
-            return "${database.identifierQuoteString}${this}${database.identifierQuoteString}".trim()
+            if (database.supportsMixedCaseQuotedIdentifiers) {
+                return "${database.identifierQuoteString}${this}${database.identifierQuoteString}"
+            } else {
+                if (database.storesUpperCaseQuotedIdentifiers) {
+                    return "${database.identifierQuoteString}${this.toUpperCase()}${database.identifierQuoteString}"
+                }
+                if (database.storesLowerCaseQuotedIdentifiers) {
+                    return "${database.identifierQuoteString}${this.toLowerCase()}${database.identifierQuoteString}"
+                }
+                return "${database.identifierQuoteString}${this}${database.identifierQuoteString}"
+            }
         } else {
-            return this
+            if (database.supportsMixedCaseIdentifiers) {
+                return this
+            } else {
+                if (database.storesUpperCaseIdentifiers) {
+                    return this.toUpperCase()
+                }
+                if (database.storesLowerCaseIdentifiers) {
+                    return this.toLowerCase()
+                }
+                return this
+            }
         }
     }
 

--- a/ktorm-core/src/main/kotlin/me/liuwj/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/me/liuwj/ktorm/expression/SqlFormatter.kt
@@ -73,12 +73,21 @@ open class SqlFormatter(
         }
     }
 
-    open protected val String.quoted: String get() {
-        if (this.toUpperCase() in database.keywords || !this.isIdentifier) {
+    protected val String.quoted: String get() {
+        val shouldQuote = database.alwaysQuoteIdentifiers
+            || !this.isIdentifier
+            || this.toUpperCase() in database.keywords
+            || this.isMixedCase && !database.supportsMixedCaseIdentifiers
+
+        if (shouldQuote) {
             return "${database.identifierQuoteString}${this}${database.identifierQuoteString}".trim()
         } else {
             return this
         }
+    }
+
+    protected val String.isMixedCase: Boolean get() {
+        return any { it.isUpperCase() } && any { it.isLowerCase() }
     }
 
     protected val String.isIdentifier: Boolean get() {

--- a/ktorm-core/src/test/kotlin/me/liuwj/ktorm/BaseTest.kt
+++ b/ktorm-core/src/test/kotlin/me/liuwj/ktorm/BaseTest.kt
@@ -23,7 +23,8 @@ open class BaseTest {
         database = Database.connect(
             url = "jdbc:h2:mem:ktorm;DB_CLOSE_DELAY=-1",
             driver = "org.h2.Driver",
-            logger = ConsoleLogger(threshold = LogLevel.TRACE)
+            logger = ConsoleLogger(threshold = LogLevel.TRACE),
+            alwaysQuoteIdentifiers = true
         )
 
         execSqlScript("init-data.sql")

--- a/ktorm-core/src/test/kotlin/me/liuwj/ktorm/database/DatabaseTest.kt
+++ b/ktorm-core/src/test/kotlin/me/liuwj/ktorm/database/DatabaseTest.kt
@@ -76,9 +76,9 @@ class DatabaseTest : BaseTest() {
     fun testRawSql() {
         val names = database.useConnection { conn ->
             val sql = """
-                select name from t_employee
-                where department_id = ?
-                order by id
+                select "name" from "t_employee"
+                where "department_id" = ?
+                order by "id"
             """
 
             conn.prepareStatement(sql).use { statement ->

--- a/ktorm-core/src/test/kotlin/me/liuwj/ktorm/database/DatabaseTest.kt
+++ b/ktorm-core/src/test/kotlin/me/liuwj/ktorm/database/DatabaseTest.kt
@@ -29,14 +29,14 @@ class DatabaseTest : BaseTest() {
 
     @Test
     fun testKeywordWrapping() {
-        val configs = object : Table<Nothing>("t_config") {
-            val key = varchar("key").primaryKey()
-            val value = varchar("value")
+        val configs = object : Table<Nothing>("T_CONFIG") {
+            val key = varchar("KEY").primaryKey()
+            val value = varchar("VALUE")
         }
 
         database.useConnection { conn ->
             conn.createStatement().use { statement ->
-                val sql = """create table t_config(`key` varchar(128) primary key, "value" varchar(128))"""
+                val sql = """CREATE TABLE T_CONFIG(KEY VARCHAR(128) PRIMARY KEY, VALUE VARCHAR(128))"""
                 statement.executeUpdate(sql)
             }
         }

--- a/ktorm-core/src/test/resources/drop-data.sql
+++ b/ktorm-core/src/test/resources/drop-data.sql
@@ -1,4 +1,4 @@
 
-drop table if exists t_department;
-drop table if exists t_employee;
-drop table if exists t_employee0;
+drop table if exists "t_department";
+drop table if exists "t_employee";
+drop table if exists "t_employee0";

--- a/ktorm-core/src/test/resources/init-data.sql
+++ b/ktorm-core/src/test/resources/init-data.sql
@@ -3,7 +3,7 @@ create table t_department(
   id int not null primary key auto_increment,
   name varchar(128) not null,
   location varchar(128) not null,
-  mixedCase varchar(128)
+  "mixedCase" varchar(128)
 );
 
 create table t_employee(

--- a/ktorm-core/src/test/resources/init-data.sql
+++ b/ktorm-core/src/test/resources/init-data.sql
@@ -1,52 +1,52 @@
 
-create table t_department(
-  id int not null primary key auto_increment,
-  name varchar(128) not null,
-  location varchar(128) not null,
+create table "t_department"(
+  "id" int not null primary key auto_increment,
+  "name" varchar(128) not null,
+  "location" varchar(128) not null,
   "mixedCase" varchar(128)
 );
 
-create table t_employee(
-  id int not null primary key auto_increment,
-  name varchar(128) not null,
-  job varchar(128) not null,
-  manager_id int null,
-  hire_date date not null,
-  salary bigint not null,
-  department_id int not null
+create table "t_employee"(
+  "id" int not null primary key auto_increment,
+  "name" varchar(128) not null,
+  "job" varchar(128) not null,
+  "manager_id" int null,
+  "hire_date" date not null,
+  "salary" bigint not null,
+  "department_id" int not null
 );
 
-insert into t_department(name, location) values ('tech', 'Guangzhou');
-insert into t_department(name, location) values ('finance', 'Beijing');
+insert into "t_department"("name", "location") values ('tech', 'Guangzhou');
+insert into "t_department"("name", "location") values ('finance', 'Beijing');
 
-insert into t_employee(name, job, manager_id, hire_date, salary, department_id)
+insert into "t_employee"("name", "job", "manager_id", "hire_date", "salary", "department_id")
     values ('vince', 'engineer', null, '2018-01-01', 100, 1);
-insert into t_employee(name, job, manager_id, hire_date, salary, department_id)
+insert into "t_employee"("name", "job", "manager_id", "hire_date", "salary", "department_id")
     values ('marry', 'trainee', 1, '2019-01-01', 50, 1);
 
-insert into t_employee(name, job, manager_id, hire_date, salary, department_id)
+insert into "t_employee"("name", "job", "manager_id", "hire_date", "salary", "department_id")
     values ('tom', 'director', null, '2018-01-01', 200, 2);
-insert into t_employee(name, job, manager_id, hire_date, salary, department_id)
+insert into "t_employee"("name", "job", "manager_id", "hire_date", "salary", "department_id")
     values ('penny', 'assistant', 3, '2019-01-01', 100, 2);
 
 
 
-create table t_employee0(
-  id int not null primary key auto_increment,
-  name varchar(128) not null,
-  job varchar(128) not null,
-  manager_id int null,
-  hire_date date not null,
-  salary bigint not null,
-  department_id int not null
+create table "t_employee0"(
+  "id" int not null primary key auto_increment,
+  "name" varchar(128) not null,
+  "job" varchar(128) not null,
+  "manager_id" int null,
+  "hire_date" date not null,
+  "salary" bigint not null,
+  "department_id" int not null
 );
 
-insert into t_employee0(name, job, manager_id, hire_date, salary, department_id)
+insert into "t_employee0"("name", "job", "manager_id", "hire_date", "salary", "department_id")
     values ('vince', 'engineer', null, '2018-01-01', 100, 1);
-insert into t_employee0(name, job, manager_id, hire_date, salary, department_id)
+insert into "t_employee0"("name", "job", "manager_id", "hire_date", "salary", "department_id")
     values ('marry', 'trainee', 1, '2019-01-01', 50, 1);
 
-insert into t_employee0(name, job, manager_id, hire_date, salary, department_id)
+insert into "t_employee0"("name", "job", "manager_id", "hire_date", "salary", "department_id")
     values ('tom', 'director', null, '2018-01-01', 200, 2);
-insert into t_employee0(name, job, manager_id, hire_date, salary, department_id)
+insert into "t_employee0"("name", "job", "manager_id", "hire_date", "salary", "department_id")
     values ('penny', 'assistant', 3, '2019-01-01', 100, 2);

--- a/ktorm-global/src/test/kotlin/me/liuwj/ktorm/global/BaseGlobalTest.kt
+++ b/ktorm-global/src/test/kotlin/me/liuwj/ktorm/global/BaseGlobalTest.kt
@@ -14,7 +14,8 @@ open class BaseGlobalTest : BaseTest() {
         database = Database.connectGlobally(
             url = "jdbc:h2:mem:ktorm;DB_CLOSE_DELAY=-1",
             driver = "org.h2.Driver",
-            logger = ConsoleLogger(threshold = LogLevel.TRACE)
+            logger = ConsoleLogger(threshold = LogLevel.TRACE),
+            alwaysQuoteIdentifiers = true
         )
 
         execSqlScript("init-data.sql")

--- a/ktorm-global/src/test/kotlin/me/liuwj/ktorm/global/GlobalDatabaseTest.kt
+++ b/ktorm-global/src/test/kotlin/me/liuwj/ktorm/global/GlobalDatabaseTest.kt
@@ -28,14 +28,14 @@ class GlobalDatabaseTest : BaseGlobalTest() {
 
     @Test
     fun testKeywordWrapping() {
-        val configs = object : Table<Nothing>("t_config") {
-            val key = varchar("key").primaryKey()
-            val value = varchar("value")
+        val configs = object : Table<Nothing>("T_CONFIG") {
+            val key = varchar("KEY").primaryKey()
+            val value = varchar("VALUE")
         }
 
         useConnection { conn ->
             conn.createStatement().use { statement ->
-                val sql = """create table t_config(`key` varchar(128) primary key, "value" varchar(128))"""
+                val sql = """CREATE TABLE T_CONFIG(KEY VARCHAR(128) PRIMARY KEY, VALUE VARCHAR(128))"""
                 statement.executeUpdate(sql)
             }
         }
@@ -75,9 +75,9 @@ class GlobalDatabaseTest : BaseGlobalTest() {
     fun testRawSql() {
         val names = useConnection { conn ->
             val sql = """
-                select name from t_employee
-                where department_id = ?
-                order by id
+                select "name" from "t_employee"
+                where "department_id" = ?
+                order by "id"
             """
 
             conn.prepareStatement(sql).use { statement ->

--- a/ktorm-support-mysql/src/test/kotlin/me/liuwj/ktorm/support/mysql/MySqlTest.kt
+++ b/ktorm-support-mysql/src/test/kotlin/me/liuwj/ktorm/support/mysql/MySqlTest.kt
@@ -41,6 +41,10 @@ class MySqlTest : BaseTest() {
         execSqlScript("init-mysql-data.sql")
     }
 
+    override fun destroy() {
+        execSqlScript("drop-mysql-data.sql")
+    }
+
     @Test
     fun testKeywordWrapping() {
         val configs = object : Table<Nothing>("t_config") {

--- a/ktorm-support-mysql/src/test/resources/drop-mysql-data.sql
+++ b/ktorm-support-mysql/src/test/resources/drop-mysql-data.sql
@@ -1,0 +1,2 @@
+drop table if exists t_department;
+drop table if exists t_employee;

--- a/ktorm-support-postgresql/src/main/kotlin/me/liuwj/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/me/liuwj/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -47,10 +47,6 @@ open class PostgreSqlFormatter(database: Database, beautifySql: Boolean, indentS
         return result
     }
 
-    override val String.quoted: String get() {
-        return "${database.identifierQuoteString}${this}${database.identifierQuoteString}".trim()
-    }
-
     override fun <T : Any> visitScalar(expr: ScalarExpression<T>): ScalarExpression<T> {
         val result = when (expr) {
             is ILikeExpression -> visitILike(expr)

--- a/ktorm-support-sqlserver/src/test/kotlin/me/liuwj/ktorm/support/sqlserver/SqlServerTest.kt
+++ b/ktorm-support-sqlserver/src/test/kotlin/me/liuwj/ktorm/support/sqlserver/SqlServerTest.kt
@@ -2,12 +2,15 @@ package me.liuwj.ktorm.support.sqlserver
 
 import me.liuwj.ktorm.BaseTest
 import me.liuwj.ktorm.database.Database
+import me.liuwj.ktorm.database.use
 import me.liuwj.ktorm.dsl.*
 import me.liuwj.ktorm.entity.count
+import me.liuwj.ktorm.entity.sequenceOf
 import me.liuwj.ktorm.logging.ConsoleLogger
 import me.liuwj.ktorm.logging.LogLevel
 import me.liuwj.ktorm.schema.Table
 import me.liuwj.ktorm.schema.datetime
+import me.liuwj.ktorm.schema.varchar
 import microsoft.sql.DateTimeOffset
 import org.junit.ClassRule
 import org.junit.Test
@@ -39,6 +42,30 @@ class SqlServerTest : BaseTest() {
 
     override fun destroy() {
         execSqlScript("drop-sqlserver-data.sql")
+    }
+
+    @Test
+    fun testKeywordWrapping() {
+        val configs = object : Table<Nothing>("t_config") {
+            val key = varchar("key").primaryKey()
+            val value = varchar("value")
+        }
+
+        database.useConnection { conn ->
+            conn.createStatement().use { statement ->
+                val sql = """create table t_config("key" varchar(128) primary key, "value" varchar(128))"""
+                statement.executeUpdate(sql)
+            }
+        }
+
+        database.insert(configs) {
+            it.key to "test"
+            it.value to "test value"
+        }
+
+        assert(database.sequenceOf(configs).count { it.key eq "test" } == 1)
+
+        database.delete(configs) { it.key eq "test" }
     }
 
     @Test


### PR DESCRIPTION
@lyndsysimon Can you help review the code? 

I just found that issue #166 is a very common case that also exists in other databases and I came up with a solution to handle it. I think this might be a better way. 

I use `DatabaseMetaData` to detect whether the current database supports mixed case for quoted or unquoted SQL identifiers:

- [supportsMixedCaseIdentifiers](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#supportsMixedCaseIdentifiers--)
- [supportsMixedCaseQuotedIdentifiers](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#supportsMixedCaseQuotedIdentifiers--)

**If mixed case is not supported for unquoted identifiers but supported for quoted ones (e.g. PostgreSQL), I will quote the mixed case identifiers to fix #166** 

I also add some additional logic for the case that mixed case is not supported (no matter quoted or not). In this case, I will auto transform the idenfiers to the correct case that the database prefers. The perfered case can be known by these methods: 

- [storesMixedCaseIdentifiers](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#storesMixedCaseIdentifiers--)
- [storesUpperCaseIdentifiers](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#storesUpperCaseIdentifiers--)
- [storesLowerCaseIdentifiers](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#storesLowerCaseIdentifiers--)
- [storesMixedCaseQuotedIdentifiers](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#storesMixedCaseQuotedIdentifiers--)
- [storesUpperCaseQuotedIdentifiers](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#storesUpperCaseQuotedIdentifiers--)
- [storesLowerCaseQuotedIdentifiers](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#storesLowerCaseQuotedIdentifiers--)