### PR TITLE
Support for PostgreSQL SKIP LOCKED

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,6 @@ Pull requests are always welcome and can be a quick way to get your fix or impro
 
 - By contributing to Ktorm, you agree to uphold our [Code of Conduct](CODE_OF_CONDUCT.md).
 - By contributing to Ktorm, you agree that your contributions will be licensed under [Apache License 2.0](LICENSE).
-- Coding Conventions are very import. Refer to the [Kotlin Style Guide](https://kotlinlang.org/docs/reference/coding-conventions.html) for the recommended coding standards of Ktorm.
+- Coding Conventions are very important. Refer to the [Kotlin Style Guide](https://kotlinlang.org/docs/reference/coding-conventions.html) for the recommended coding standards of Ktorm.
 - If you've added code that should be tested, add tests and ensure they all pass. If you've changed APIs, update the documentation. 
 - If it's your first time contributing to Ktorm, please also update the `build.gradle` file, add your GitHub ID to the developers info, which will let more people know your contributions.

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         kotlinVersion = "1.4.21"
-        detektVersion = "1.12.0-RC1"
+        detektVersion = "1.14.2"
     }
     repositories {
         jcenter()
@@ -161,6 +161,11 @@ subprojects { project ->
                             id = "pedrod"
                             name = "Pedro Domingues"
                             email = "pedro.domingues.pt@gmail.com"
+                        }
+                        developer {
+                            id = "sigmanil"
+                            name = "Sigmund M. Nilssen"
+                            email = "sigmundn@gmail.com"
                         }
                     }
                     scm {

--- a/ktorm-support-mysql/ktorm-support-mysql.gradle
+++ b/ktorm-support-mysql/ktorm-support-mysql.gradle
@@ -5,5 +5,5 @@ dependencies {
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
     testImplementation project(":ktorm-jackson")
     testImplementation "mysql:mysql-connector-java:8.0.13"
-    testImplementation "org.testcontainers:mysql:1.11.3"
+    testImplementation "org.testcontainers:mysql:1.15.1"
 }

--- a/ktorm-support-oracle/ktorm-support-oracle.gradle
+++ b/ktorm-support-oracle/ktorm-support-oracle.gradle
@@ -4,5 +4,5 @@ dependencies {
 
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
     testImplementation fileTree(dir: "lib", includes: ["*.jar"])
-    testImplementation "org.testcontainers:oracle-xe:1.11.3"
+    testImplementation "org.testcontainers:oracle-xe:1.15.1"
 }

--- a/ktorm-support-postgresql/ktorm-support-postgresql.gradle
+++ b/ktorm-support-postgresql/ktorm-support-postgresql.gradle
@@ -4,5 +4,5 @@ dependencies {
 
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
     testImplementation "org.postgresql:postgresql:42.2.5"
-    testImplementation "org.testcontainers:postgresql:1.11.3"
+    testImplementation "org.testcontainers:postgresql:1.15.1"
 }

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -146,6 +146,14 @@ public open class PostgreSqlFormatter(
         return expr
     }
 
+    override fun visitSelect(expr: SelectExpression): SelectExpression {
+        super.visitSelect(expr)
+        if (expr.extraProperties[SKIP_LOCKED] == true) {
+            writeKeyword("skip locked ")
+        }
+        return expr
+    }
+
     protected open fun visitInsertOrUpdate(expr: InsertOrUpdateExpression): InsertOrUpdateExpression {
         writeKeyword("insert into ")
         visitTable(expr.table)

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/SkipLocked.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/SkipLocked.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.support.postgresql
+
+import org.ktorm.dsl.Query
+import org.ktorm.entity.EntitySequence
+import org.ktorm.expression.SelectExpression
+import org.ktorm.expression.UnionExpression
+import org.ktorm.schema.BaseTable
+
+internal const val SKIP_LOCKED = "skipLocked"
+
+/**
+ * Indicate that this query should skip locked records, the generated SQL would be `select ... skip locked`.
+ */
+public fun Query.skipLocked(): Query {
+    val expr = when (expression) {
+        is SelectExpression ->
+            (expression as SelectExpression)
+                .copy(extraProperties = expression.extraProperties + (SKIP_LOCKED to true))
+        is UnionExpression ->
+            throw IllegalStateException("SELECT SKIP LOCKS is not supported in a union expression.")
+    }
+
+    return this.withExpression(expr)
+}
+
+/**
+ * Indicate that the generated query should skip locked records, the generated SQL would be `select ... skip locked`.
+ */
+public fun <E : Any, T : BaseTable<E>> EntitySequence<E, T>.skipLocked(): EntitySequence<E, T> {
+    return this.withExpression(expression.copy(extraProperties = expression.extraProperties + (SKIP_LOCKED to true)))
+}

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -501,8 +501,6 @@ class PostgreSqlTest : BaseTest() {
         val skippedFuture = Executors.newSingleThreadExecutor().submit {
             assertTrue(readyToTestSkipLocksLatch.await(5, TimeUnit.SECONDS))
             val employees = database.useTransaction(isolation = TransactionIsolation.REPEATABLE_READ) {
-                System.err.println("Cake: ${database.transactionManager.currentTransaction}")
-
                 database
                     .sequenceOf(Employees, withReferences = false)
                     .filter { it.id eq 1 }
@@ -512,14 +510,12 @@ class PostgreSqlTest : BaseTest() {
             }
             testSkipLocksDoneLatch.countDown()
             if (employees.isNotEmpty()) {
-                System.err.println(employees)
                 throw java.lang.IllegalStateException("Entry should have been skipped due to being locked.")
             }
         }
 
         val selectedFuture = Executors.newSingleThreadExecutor().submit {
             val employees = database.useTransaction(isolation = TransactionIsolation.REPEATABLE_READ) {
-                System.err.println(database.transactionManager.currentTransaction)
                 val employeeList = database
                     .sequenceOf(Employees, withReferences = false)
                     .filter { it.id eq 1 }

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -18,6 +18,7 @@ import org.ktorm.schema.Table
 import org.ktorm.schema.int
 import org.ktorm.schema.varchar
 import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
 import java.time.LocalDate
 import java.util.concurrent.*
 
@@ -27,7 +28,7 @@ import java.util.concurrent.*
 class PostgreSqlTest : BaseTest() {
 
     companion object {
-        class KPostgreSqlContainer : PostgreSQLContainer<KPostgreSqlContainer>()
+        class KPostgreSqlContainer : PostgreSQLContainer<KPostgreSqlContainer>("postgres:13.1-alpine")
 
         @ClassRule
         @JvmField
@@ -493,13 +494,15 @@ class PostgreSqlTest : BaseTest() {
     }
 
     @Test
-    fun testSelctForUpdateSkipLocked() {
+    fun testSelectForUpdateSkipLocked() {
         val readyToTestSkipLocksLatch = CountDownLatch(1)
         val testSkipLocksDoneLatch = CountDownLatch(1)
 
         val skippedFuture = Executors.newSingleThreadExecutor().submit {
             assertTrue(readyToTestSkipLocksLatch.await(5, TimeUnit.SECONDS))
             val employees = database.useTransaction(isolation = TransactionIsolation.REPEATABLE_READ) {
+                System.err.println("Cake: ${database.transactionManager.currentTransaction}")
+
                 database
                     .sequenceOf(Employees, withReferences = false)
                     .filter { it.id eq 1 }
@@ -509,29 +512,32 @@ class PostgreSqlTest : BaseTest() {
             }
             testSkipLocksDoneLatch.countDown()
             if (employees.isNotEmpty()) {
+                System.err.println(employees)
                 throw java.lang.IllegalStateException("Entry should have been skipped due to being locked.")
             }
         }
 
         val selectedFuture = Executors.newSingleThreadExecutor().submit {
             val employees = database.useTransaction(isolation = TransactionIsolation.REPEATABLE_READ) {
-                database
+                System.err.println(database.transactionManager.currentTransaction)
+                val employeeList = database
                     .sequenceOf(Employees, withReferences = false)
                     .filter { it.id eq 1 }
                     .forUpdate()
                     .skipLocked()
                     .toList()
+
+                readyToTestSkipLocksLatch.countDown()
+                assertTrue(testSkipLocksDoneLatch.await(10, TimeUnit.SECONDS))
+                employeeList
             }
-            readyToTestSkipLocksLatch.countDown()
             if (employees.size != 1) {
                 throw java.lang.IllegalStateException("Entry should be available.")
             }
         }
 
-        assertTrue(testSkipLocksDoneLatch.await(10, TimeUnit.SECONDS))
+        assertNull(selectedFuture.get(5, TimeUnit.SECONDS))
+        assertNull(skippedFuture.get(5, TimeUnit.SECONDS))
 
-        assertNull(selectedFuture.get(5, TimeUnit.SECONDS))
-        assertNull(selectedFuture.get(5, TimeUnit.SECONDS))
-        
     }
 }

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -532,32 +532,6 @@ class PostgreSqlTest : BaseTest() {
 
         assertNull(selectedFuture.get(5, TimeUnit.SECONDS))
         assertNull(selectedFuture.get(5, TimeUnit.SECONDS))
-
-//
-//
-//        database.useTransaction {
-//            val employee = database
-//                .sequenceOf(Employees, withReferences = false)
-//                .filter { it.id eq 1 }
-//                .forUpdate()
-//                .skipLocked()
-//                .first()
-//
-//            val future = Executors.newSingleThreadExecutor().submit {
-//                employee.name = "vince"
-//                employee.flushChanges()
-//            }
-//
-//            try {
-//                future.get(5, TimeUnit.SECONDS)
-//                throw AssertionError()
-//            } catch (e: ExecutionException) {
-//                // Expected, the record is locked.
-//                e.printStackTrace()
-//            } catch (e: TimeoutException) {
-//                // Expected, the record is locked.
-//                e.printStackTrace()
-//            }
-//        }
+        
     }
 }

--- a/ktorm-support-sqlserver/ktorm-support-sqlserver.gradle
+++ b/ktorm-support-sqlserver/ktorm-support-sqlserver.gradle
@@ -4,5 +4,5 @@ dependencies {
     api "com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8"
 
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
-    testImplementation "org.testcontainers:mssqlserver:1.11.3"
+    testImplementation "org.testcontainers:mssqlserver:1.15.1"
 }


### PR DESCRIPTION
This code allows for SKIP LOCKED to be used in the postgres dialect.

I had to upgrade some libraries for the gradle build to run green on my machine, these upgrades are also included here.

Please let me know if something here isn't up to your standards, and I'll try to fix it.