### PR TITLE
For update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         kotlinVersion = "1.4.21"
-        detektVersion = "1.12.0-RC1"
+        detektVersion = "1.15.0"
     }
     repositories {
         jcenter()

--- a/ktorm-core/src/main/kotlin/org/ktorm/database/SqlDialect.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/database/SqlDialect.kt
@@ -17,6 +17,7 @@
 package org.ktorm.database
 
 import org.ktorm.expression.ArgumentExpression
+import org.ktorm.expression.ForUpdateOption
 import org.ktorm.expression.QueryExpression
 import org.ktorm.expression.SqlFormatter
 import java.sql.Statement
@@ -50,6 +51,10 @@ public interface SqlDialect {
      */
     public fun createSqlFormatter(database: Database, beautifySql: Boolean, indentSize: Int): SqlFormatter {
         return object : SqlFormatter(database, beautifySql, indentSize) {
+            override fun writeForUpdate(forUpdate: ForUpdateOption) {
+                throw DialectFeatureNotSupportedException("ForUpdate is not supported in Standard SQL.")
+            }
+
             override fun writePagination(expr: QueryExpression) {
                 throw DialectFeatureNotSupportedException("Pagination is not supported in Standard SQL.")
             }

--- a/ktorm-core/src/main/kotlin/org/ktorm/dsl/Query.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/dsl/Query.kt
@@ -767,9 +767,9 @@ public fun Query.joinToString(
  *
  * @since 3.1.0
  */
-public fun Query.forUpdate(forUpdateExpression: ForUpdateExpression?): Query {
+public fun Query.forUpdate(forUpdate: ForUpdateOption?): Query {
     val expr = when (expression) {
-        is SelectExpression -> expression.copy(forUpdate = forUpdateExpression)
+        is SelectExpression -> expression.copy(forUpdate = forUpdate)
         is UnionExpression -> throw IllegalStateException("SELECT FOR UPDATE is not supported in a union expression.")
     }
 

--- a/ktorm-core/src/main/kotlin/org/ktorm/dsl/Query.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/dsl/Query.kt
@@ -767,7 +767,7 @@ public fun Query.joinToString(
  *
  * @since 3.1.0
  */
-public fun Query.forUpdate(forUpdate: ForUpdateOption?): Query {
+public fun Query.forUpdate(forUpdate: ForUpdateOption): Query {
     val expr = when (expression) {
         is SelectExpression -> expression.copy(forUpdate = forUpdate)
         is UnionExpression -> throw IllegalStateException("SELECT FOR UPDATE is not supported in a union expression.")

--- a/ktorm-core/src/main/kotlin/org/ktorm/dsl/Query.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/dsl/Query.kt
@@ -763,13 +763,13 @@ public fun Query.joinToString(
 }
 
 /**
- * Indicate that this query should aquire the record-lock, the generated SQL would be `select ... for update`.
+ * Indicate that this query should acquire an update-lock, the generated SQL will depend on the SqlDialect.
  *
  * @since 3.1.0
  */
-public fun Query.forUpdate(): Query {
+public fun Query.forUpdate(forUpdateExpression: ForUpdateExpression?): Query {
     val expr = when (expression) {
-        is SelectExpression -> expression.copy(forUpdate = true)
+        is SelectExpression -> expression.copy(forUpdate = forUpdateExpression)
         is UnionExpression -> throw IllegalStateException("SELECT FOR UPDATE is not supported in a union expression.")
     }
 

--- a/ktorm-core/src/main/kotlin/org/ktorm/entity/EntityImplementation.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/entity/EntityImplementation.kt
@@ -227,7 +227,7 @@ internal class EntityImplementation(
     }
 
     override fun hashCode(): Int {
-        return values.hashCode() + (13 * entityClass.hashCode())
+        return values.hashCode() + 13 * entityClass.hashCode()
     }
 
     override fun toString(): String {

--- a/ktorm-core/src/main/kotlin/org/ktorm/entity/EntitySequence.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/entity/EntitySequence.kt
@@ -1511,6 +1511,6 @@ public fun <E : Any> EntitySequence<E, *>.joinToString(
  * @since 3.1.0
  */
 public fun <E : Any, T : BaseTable<E>> EntitySequence<E, T>.forUpdate(
-    forUpdate: ForUpdateOption?): EntitySequence<E, T> {
+    forUpdate: ForUpdateOption): EntitySequence<E, T> {
     return this.withExpression(expression.copy(forUpdate = forUpdate))
 }

--- a/ktorm-core/src/main/kotlin/org/ktorm/entity/EntitySequence.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/entity/EntitySequence.kt
@@ -19,6 +19,7 @@ package org.ktorm.entity
 import org.ktorm.database.Database
 import org.ktorm.database.DialectFeatureNotSupportedException
 import org.ktorm.dsl.*
+import org.ktorm.expression.ForUpdateExpression
 import org.ktorm.expression.OrderByExpression
 import org.ktorm.expression.SelectExpression
 import org.ktorm.schema.BaseTable
@@ -1505,10 +1506,11 @@ public fun <E : Any> EntitySequence<E, *>.joinToString(
 }
 
 /**
- * Indicate that this query should aquire the record-lock, the generated SQL would be `select ... for update`.
+ * Indicate that this query should acquire an update-lock, the generated SQL will depend on the SqlDialect.
  *
  * @since 3.1.0
  */
-public fun <E : Any, T : BaseTable<E>> EntitySequence<E, T>.forUpdate(): EntitySequence<E, T> {
-    return this.withExpression(expression.copy(forUpdate = true))
+public fun <E : Any, T : BaseTable<E>> EntitySequence<E, T>.forUpdate(
+    forUpdateExpression: ForUpdateExpression?): EntitySequence<E, T> {
+    return this.withExpression(expression.copy(forUpdate = forUpdateExpression))
 }

--- a/ktorm-core/src/main/kotlin/org/ktorm/entity/EntitySequence.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/entity/EntitySequence.kt
@@ -19,7 +19,7 @@ package org.ktorm.entity
 import org.ktorm.database.Database
 import org.ktorm.database.DialectFeatureNotSupportedException
 import org.ktorm.dsl.*
-import org.ktorm.expression.ForUpdateExpression
+import org.ktorm.expression.ForUpdateOption
 import org.ktorm.expression.OrderByExpression
 import org.ktorm.expression.SelectExpression
 import org.ktorm.schema.BaseTable
@@ -1511,6 +1511,6 @@ public fun <E : Any> EntitySequence<E, *>.joinToString(
  * @since 3.1.0
  */
 public fun <E : Any, T : BaseTable<E>> EntitySequence<E, T>.forUpdate(
-    forUpdateExpression: ForUpdateExpression?): EntitySequence<E, T> {
-    return this.withExpression(expression.copy(forUpdate = forUpdateExpression))
+    forUpdate: ForUpdateOption?): EntitySequence<E, T> {
+    return this.withExpression(expression.copy(forUpdate = forUpdate))
 }

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
@@ -125,7 +125,7 @@ public data class SelectExpression(
     val groupBy: List<ScalarExpression<*>> = emptyList(),
     val having: ScalarExpression<Boolean>? = null,
     val isDistinct: Boolean = false,
-    val forUpdate: ForUpdateOption? = null,
+    val forUpdate: ForUpdateOption = ForUpdateOption.None,
     override val orderBy: List<OrderByExpression> = emptyList(),
     override val offset: Int? = null,
     override val limit: Int? = null,
@@ -136,7 +136,11 @@ public data class SelectExpression(
 /**
  * ForUpdateOption, database-specific implementations are in support module for each database dialect.
  */
-public interface ForUpdateOption
+public interface ForUpdateOption {
+    public companion object {
+        public val None: ForUpdateOption = object : ForUpdateOption {}
+    }
+}
 
 /**
  * Union expression, represents a `union` statement of SQL.

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
@@ -115,7 +115,8 @@ public sealed class QueryExpression : QuerySourceExpression() {
  * @property groupBy the grouping conditions, represents the `group by` clause of SQL.
  * @property having the having condition, represents the `having` clause of SQL.
  * @property isDistinct mark if this query is distinct, true means the SQL is `select distinct ...`.
- * @property forUpdate mark if this query should aquire the record-lock, true means the SQL is `select ... for update`.
+ * @property forUpdate mark if this query should acquire an update-lock, non-null will generate a dialect-specific
+ * `for update` clause.
  */
 public data class SelectExpression(
     val columns: List<ColumnDeclaringExpression<*>> = emptyList(),

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
@@ -19,7 +19,6 @@ package org.ktorm.expression
 import org.ktorm.schema.BooleanSqlType
 import org.ktorm.schema.ColumnDeclaring
 import org.ktorm.schema.SqlType
-import org.ktorm.schema.VarcharSqlType
 
 /**
  * Root class of SQL expressions or statements.
@@ -125,7 +124,7 @@ public data class SelectExpression(
     val groupBy: List<ScalarExpression<*>> = emptyList(),
     val having: ScalarExpression<Boolean>? = null,
     val isDistinct: Boolean = false,
-    val forUpdate: ForUpdateExpression? = null,
+    val forUpdate: ForUpdateOption? = null,
     override val orderBy: List<OrderByExpression> = emptyList(),
     override val offset: Int? = null,
     override val limit: Int? = null,
@@ -134,16 +133,9 @@ public data class SelectExpression(
 ) : QueryExpression()
 
 /**
- * For Update expression, implementations are in the MySql and Postgres Dialects.
+ * ForUpdateOption, implementations are in the MySql and Postgres Dialects.
  */
-public abstract class ForUpdateExpression : ScalarExpression<String>() {
-    override val isLeafNode: Boolean
-        get() = true
-    override val extraProperties: Map<String, Any>
-        get() = emptyMap()
-    override val sqlType: SqlType<String>
-        get() = VarcharSqlType
-}
+public interface ForUpdateOption
 
 /**
  * Union expression, represents a `union` statement of SQL.

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
@@ -19,6 +19,7 @@ package org.ktorm.expression
 import org.ktorm.schema.BooleanSqlType
 import org.ktorm.schema.ColumnDeclaring
 import org.ktorm.schema.SqlType
+import org.ktorm.schema.VarcharSqlType
 
 /**
  * Root class of SQL expressions or statements.
@@ -124,13 +125,25 @@ public data class SelectExpression(
     val groupBy: List<ScalarExpression<*>> = emptyList(),
     val having: ScalarExpression<Boolean>? = null,
     val isDistinct: Boolean = false,
-    val forUpdate: Boolean = false,
+    val forUpdate: ForUpdateExpression? = null,
     override val orderBy: List<OrderByExpression> = emptyList(),
     override val offset: Int? = null,
     override val limit: Int? = null,
     override val tableAlias: String? = null,
     override val extraProperties: Map<String, Any> = emptyMap()
 ) : QueryExpression()
+
+/**
+ * For Update expression, implementations are in the MySql and Postgres Dialects.
+ */
+public abstract class ForUpdateExpression : ScalarExpression<String>() {
+    override val isLeafNode: Boolean
+        get() = true
+    override val extraProperties: Map<String, Any>
+        get() = emptyMap()
+    override val sqlType: SqlType<String>
+        get() = VarcharSqlType
+}
 
 /**
  * Union expression, represents a `union` statement of SQL.

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
@@ -133,7 +133,7 @@ public data class SelectExpression(
 ) : QueryExpression()
 
 /**
- * ForUpdateOption, implementations are in the MySql and Postgres Dialects.
+ * ForUpdateOption, database-specific implementations are in support module for each database dialect.
  */
 public interface ForUpdateOption
 

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -394,7 +394,7 @@ public abstract class SqlFormatter(
         return expr
     }
 
-    protected abstract fun writeForUpdate(expr: ForUpdateOption)
+    protected abstract fun writeForUpdate(forUpdate: ForUpdateOption)
 
     override fun visitQuerySource(expr: QuerySourceExpression): QuerySourceExpression {
         when (expr) {

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -18,7 +18,6 @@ package org.ktorm.expression
 
 import org.ktorm.database.Database
 import org.ktorm.database.DialectFeatureNotSupportedException
-import org.ktorm.database.detectDialectImplementation
 
 /**
  * Subclass of [SqlExpressionVisitor], visiting SQL expression trees using visitor pattern. After the visit completes,
@@ -390,15 +389,12 @@ public abstract class SqlFormatter(
             writePagination(expr)
         }
         if (expr.forUpdate != null) {
-            visitForUpdate(expr.forUpdate)
+            writeForUpdate(expr.forUpdate)
         }
         return expr
     }
 
-    protected open fun visitForUpdate(expr: ForUpdateExpression): ForUpdateExpression =
-        throw DialectFeatureNotSupportedException(
-            "FOR UPDATE not supported in dialect ${detectDialectImplementation()::class.java.name}."
-        )
+    protected abstract fun writeForUpdate(expr: ForUpdateExpression)
 
     override fun visitQuerySource(expr: QuerySourceExpression): QuerySourceExpression {
         when (expr) {

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -388,7 +388,7 @@ public abstract class SqlFormatter(
         if (expr.offset != null || expr.limit != null) {
             writePagination(expr)
         }
-        if (expr.forUpdate != null) {
+        if (expr.forUpdate != ForUpdateOption.None) {
             writeForUpdate(expr.forUpdate)
         }
         return expr

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -394,7 +394,7 @@ public abstract class SqlFormatter(
         return expr
     }
 
-    protected abstract fun writeForUpdate(expr: ForUpdateExpression)
+    protected abstract fun writeForUpdate(expr: ForUpdateOption)
 
     override fun visitQuerySource(expr: QuerySourceExpression): QuerySourceExpression {
         when (expr) {

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -18,6 +18,7 @@ package org.ktorm.expression
 
 import org.ktorm.database.Database
 import org.ktorm.database.DialectFeatureNotSupportedException
+import org.ktorm.database.detectDialectImplementation
 
 /**
  * Subclass of [SqlExpressionVisitor], visiting SQL expression trees using visitor pattern. After the visit completes,
@@ -388,11 +389,16 @@ public abstract class SqlFormatter(
         if (expr.offset != null || expr.limit != null) {
             writePagination(expr)
         }
-        if (expr.forUpdate) {
-            writeKeyword("for update ")
+        if (expr.forUpdate != null) {
+            visitForUpdate(expr.forUpdate)
         }
         return expr
     }
+
+    protected open fun visitForUpdate(expr: ForUpdateExpression): ForUpdateExpression =
+        throw DialectFeatureNotSupportedException(
+            "FOR UPDATE not supported in dialect ${detectDialectImplementation()::class.java.name}."
+        )
 
     override fun visitQuerySource(expr: QuerySourceExpression): QuerySourceExpression {
         when (expr) {

--- a/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
+++ b/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
@@ -260,33 +260,6 @@ class QueryTest : BaseTest() {
     }
 
     @Test
-    fun testSelctForUpdate() {
-        database.useTransaction {
-            val employee = database
-                .sequenceOf(Employees, withReferences = false)
-                .filter { it.id eq 1 }
-                .forUpdate()
-                .first()
-
-            val future = Executors.newSingleThreadExecutor().submit {
-                employee.name = "vince"
-                employee.flushChanges()
-            }
-
-            try {
-                future.get(5, TimeUnit.SECONDS)
-                throw AssertionError()
-            } catch (e: ExecutionException) {
-                // Expected, the record is locked.
-                e.printStackTrace()
-            } catch (e: TimeoutException) {
-                // Expected, the record is locked.
-                e.printStackTrace()
-            }
-        }
-    }
-
-    @Test
     fun testFlatMap() {
         val names = database
             .from(Employees)

--- a/ktorm-support-mysql/ktorm-support-mysql.gradle
+++ b/ktorm-support-mysql/ktorm-support-mysql.gradle
@@ -5,5 +5,5 @@ dependencies {
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
     testImplementation project(":ktorm-jackson")
     testImplementation "mysql:mysql-connector-java:8.0.13"
-    testImplementation "org.testcontainers:mysql:1.11.3"
+    testImplementation "org.testcontainers:mysql:1.15.1"
 }

--- a/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
@@ -17,6 +17,7 @@
 package org.ktorm.support.mysql
 
 import org.ktorm.database.Database
+import org.ktorm.database.DialectFeatureNotSupportedException
 import org.ktorm.database.SqlDialect
 import org.ktorm.expression.*
 import org.ktorm.schema.IntSqlType
@@ -166,12 +167,12 @@ public open class MySqlFormatter(
         return expr
     }
 
-    override fun writeForUpdate(expr: ForUpdateOption) {
+    override fun writeForUpdate(forUpdate: ForUpdateOption) {
         when {
-            expr == ForUpdate -> writeKeyword("for update ")
-            expr == ForShare && version == MySql5 -> writeKeyword("lock in share mode ")
-            expr == ForShare && version == MySql8 -> writeKeyword("for share ")
-            else -> { /* no-op */ }
+            forUpdate == ForUpdate -> writeKeyword("for update ")
+            forUpdate == ForShare && version == MySql5 -> writeKeyword("lock in share mode ")
+            forUpdate == ForShare && version == MySql8 -> writeKeyword("for share ")
+            else -> throw DialectFeatureNotSupportedException("Unsupported ForUpdateOption ${forUpdate::class.java.name}.")
         }
     }
 }

--- a/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
@@ -43,13 +43,13 @@ private enum class Version(val majorVersion: Int) {
 }
 
 /**
- * Thrown to indicate that the MySql version is not supported by the current dialect.
+ * Thrown to indicate that the MySql version is not supported by the dialect.
  *
  * @param databaseMetaData used to format the exception's message.
  */
 public class UnsupportedMySqlVersionException(databaseMetaData: DatabaseMetaData) :
     UnsupportedOperationException(
-        "Unsupported SqlDialect for ${databaseMetaData.databaseProductName} v${databaseMetaData.databaseProductVersion}"
+        "Unsupported MySql version ${databaseMetaData.databaseProductVersion}."
     ) {
     private companion object {
         private const val serialVersionUID = 1L

--- a/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
@@ -184,7 +184,7 @@ public open class MySqlFormatter(
  */
 public sealed class MySqlForUpdateOption : ForUpdateOption {
     /**
-     * The generated SQL would be `select ... lock in share mode` for MySql 5 and `select .. for share` for MySql 8.
+     * The generated SQL would be `select ... lock in share mode` for MySql 5 and `select ... for share` for MySql 8.
      **/
     public object ForShare : MySqlForUpdateOption()
     /** The generated SQL would be `select ... for update`. */

--- a/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
@@ -21,8 +21,8 @@ import org.ktorm.database.SqlDialect
 import org.ktorm.expression.*
 import org.ktorm.schema.IntSqlType
 import org.ktorm.schema.VarcharSqlType
-import org.ktorm.support.mysql.MySqlForUpdateExpression.ForShare
-import org.ktorm.support.mysql.MySqlForUpdateExpression.ForUpdate
+import org.ktorm.support.mysql.MySqlForUpdateOption.ForShare
+import org.ktorm.support.mysql.MySqlForUpdateOption.ForUpdate
 import org.ktorm.support.mysql.Version.MySql5
 import org.ktorm.support.mysql.Version.MySql8
 import java.sql.DatabaseMetaData
@@ -166,7 +166,7 @@ public open class MySqlFormatter(
         return expr
     }
 
-    override fun writeForUpdate(expr: ForUpdateExpression) {
+    override fun writeForUpdate(expr: ForUpdateOption) {
         when {
             expr == ForUpdate -> writeKeyword("for update ")
             expr == ForShare && version == MySql5 -> writeKeyword("lock in share mode ")
@@ -179,13 +179,13 @@ public open class MySqlFormatter(
 /**
  * MySql Specific ForUpdateExpressions.
  */
-public sealed class MySqlForUpdateExpression : ForUpdateExpression() {
+public sealed class MySqlForUpdateOption : ForUpdateOption {
     /**
      * The generated SQL would be `select ... lock in share mode` for MySql 5 and `select .. for share` for MySql 8.
      **/
-    public object ForShare : MySqlForUpdateExpression()
+    public object ForShare : MySqlForUpdateOption()
     /** The generated SQL would be `select ... for update`. */
-    public object ForUpdate : MySqlForUpdateExpression()
+    public object ForUpdate : MySqlForUpdateOption()
 }
 
 /**

--- a/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
@@ -172,13 +172,15 @@ public open class MySqlFormatter(
             forUpdate == ForUpdate -> writeKeyword("for update ")
             forUpdate == ForShare && version == MySql5 -> writeKeyword("lock in share mode ")
             forUpdate == ForShare && version == MySql8 -> writeKeyword("for share ")
-            else -> throw DialectFeatureNotSupportedException("Unsupported ForUpdateOption ${forUpdate::class.java.name}.")
+            else -> throw DialectFeatureNotSupportedException(
+                "Unsupported ForUpdateOption ${forUpdate::class.java.name}."
+            )
         }
     }
 }
 
 /**
- * MySql Specific ForUpdateExpressions.
+ * MySql Specific ForUpdateOptions.
  */
 public sealed class MySqlForUpdateOption : ForUpdateOption {
     /**

--- a/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/MySqlDialect.kt
@@ -166,14 +166,13 @@ public open class MySqlFormatter(
         return expr
     }
 
-    override fun visitForUpdate(expr: ForUpdateExpression): ForUpdateExpression {
+    override fun writeForUpdate(expr: ForUpdateExpression) {
         when {
             expr == ForUpdate -> writeKeyword("for update ")
             expr == ForShare && version == MySql5 -> writeKeyword("lock in share mode ")
             expr == ForShare && version == MySql8 -> writeKeyword("for share ")
             else -> { /* no-op */ }
         }
-        return expr
     }
 }
 

--- a/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/MySqlTest.kt
+++ b/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/MySqlTest.kt
@@ -422,7 +422,7 @@ class MySqlTest : BaseTest() {
             val employee = database
                 .sequenceOf(Employees, withReferences = false)
                 .filter { it.id eq 1 }
-                .forUpdate(MySqlForUpdateExpression.ForUpdate)
+                .forUpdate(MySqlForUpdateOption.ForUpdate)
                 .first()
 
             val future = Executors.newSingleThreadExecutor().submit {

--- a/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/MySqlTest.kt
+++ b/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/MySqlTest.kt
@@ -36,7 +36,7 @@ class MySqlTest : BaseTest() {
         const val ID_3 = 3
         const val ID_4 = 4
 
-        class KMySqlContainer : MySQLContainer<KMySqlContainer>()
+        class KMySqlContainer : MySQLContainer<KMySqlContainer>("mysql:8")
 
         @ClassRule
         @JvmField

--- a/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/MySqlTest.kt
+++ b/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/MySqlTest.kt
@@ -417,12 +417,12 @@ class MySqlTest : BaseTest() {
     }
 
     @Test
-    fun testSelctForUpdate() {
+    fun testSelectForUpdate() {
         database.useTransaction {
             val employee = database
                 .sequenceOf(Employees, withReferences = false)
                 .filter { it.id eq 1 }
-                .forUpdate()
+                .forUpdate(MySqlForUpdateExpression.ForUpdate)
                 .first()
 
             val future = Executors.newSingleThreadExecutor().submit {

--- a/ktorm-support-oracle/ktorm-support-oracle.gradle
+++ b/ktorm-support-oracle/ktorm-support-oracle.gradle
@@ -4,5 +4,5 @@ dependencies {
 
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
     testImplementation fileTree(dir: "lib", includes: ["*.jar"])
-    testImplementation "org.testcontainers:oracle-xe:1.11.3"
+    testImplementation "org.testcontainers:oracle-xe:1.15.1"
 }

--- a/ktorm-support-oracle/src/main/kotlin/org/ktorm/support/oracle/OracleDialect.kt
+++ b/ktorm-support-oracle/src/main/kotlin/org/ktorm/support/oracle/OracleDialect.kt
@@ -73,7 +73,7 @@ public open class OracleFormatter(
         if (expr.offset == null && expr.limit == null) {
             return super.visitQuery(expr)
         }
-        if (expr is SelectExpression && expr.forUpdate != null) {
+        if (expr is SelectExpression && expr.forUpdate != ForUpdateOption.None) {
             throw DialectFeatureNotSupportedException("SELECT FOR UPDATE not supported when using offset/limit params.")
         }
 

--- a/ktorm-support-oracle/src/test/kotlin/org/ktorm/support/oracle/OracleTest.kt
+++ b/ktorm-support-oracle/src/test/kotlin/org/ktorm/support/oracle/OracleTest.kt
@@ -155,7 +155,7 @@ class OracleTest : BaseTest() {
             val employee = database
                 .sequenceOf(Employees, withReferences = false)
                 .filter { it.id eq 1 }
-                .forUpdate()
+                .forUpdate(OracleForUpdateOption.ForUpdate)
                 .single()
 
             val future = Executors.newSingleThreadExecutor().submit {

--- a/ktorm-support-postgresql/ktorm-support-postgresql.gradle
+++ b/ktorm-support-postgresql/ktorm-support-postgresql.gradle
@@ -4,5 +4,5 @@ dependencies {
 
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
     testImplementation "org.postgresql:postgresql:42.2.5"
-    testImplementation "org.testcontainers:postgresql:1.11.3"
+    testImplementation "org.testcontainers:postgresql:1.15.1"
 }

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -39,7 +39,7 @@ public open class PostgreSqlDialect : SqlDialect {
 public class PostgresForUpdateOption(
     private val lockStrength: LockStrength,
     private val onLock: OnLock,
-    private vararg val tables: Table<*> = emptyArray()
+    private vararg val tables: Table<*>
 ) : ForUpdateOption {
     public fun toLockingClause(): String {
         val lockingClause = StringBuilder(lockStrength.keywords)

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -52,13 +52,13 @@ public sealed class PostgresForUpdateExpression : ForUpdateExpression() {
 public open class PostgreSqlFormatter(
     database: Database, beautifySql: Boolean, indentSize: Int
 ) : SqlFormatter(database, beautifySql, indentSize) {
-    override fun visitForUpdate(forUpdate: ForUpdateExpression): ForUpdateExpression {
-        when (forUpdate) {
+    override fun writeForUpdate(expr: ForUpdateExpression) {
+        when (expr) {
             SkipLocked -> writeKeyword("for update skip locked ")
             NoWait -> writeKeyword("for update nowait ")
-            is Wait -> writeKeyword("for update wait ${forUpdate.seconds} ")
+            is Wait -> writeKeyword("for update wait ${expr.seconds} ")
+            else -> { /* no-op */ }
         }
-        return forUpdate
     }
 
     override fun checkColumnName(name: String) {

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -36,7 +36,7 @@ public open class PostgreSqlDialect : SqlDialect {
 }
 
 /**
- * Postgres Specific ForUpdateExpressions.
+ * Postgres Specific ForUpdateOptions.
  */
 public sealed class PostgresForUpdateOption : ForUpdateOption {
     /** The generated SQL would be `select ... for update skip locked`. */
@@ -58,7 +58,9 @@ public open class PostgreSqlFormatter(
             SkipLocked -> writeKeyword("for update skip locked ")
             NoWait -> writeKeyword("for update nowait ")
             is Wait -> writeKeyword("for update wait ${forUpdate.seconds} ")
-            else -> throw DialectFeatureNotSupportedException("Unsupported ForUpdateOption ${forUpdate::class.java.name}.")
+            else -> throw DialectFeatureNotSupportedException(
+                "Unsupported ForUpdateOption ${forUpdate::class.java.name}."
+            )
         }
     }
 

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -17,6 +17,7 @@
 package org.ktorm.support.postgresql
 
 import org.ktorm.database.Database
+import org.ktorm.database.DialectFeatureNotSupportedException
 import org.ktorm.database.SqlDialect
 import org.ktorm.expression.*
 import org.ktorm.schema.IntSqlType
@@ -52,12 +53,12 @@ public sealed class PostgresForUpdateOption : ForUpdateOption {
 public open class PostgreSqlFormatter(
     database: Database, beautifySql: Boolean, indentSize: Int
 ) : SqlFormatter(database, beautifySql, indentSize) {
-    override fun writeForUpdate(expr: ForUpdateOption) {
-        when (expr) {
+    override fun writeForUpdate(forUpdate: ForUpdateOption) {
+        when (forUpdate) {
             SkipLocked -> writeKeyword("for update skip locked ")
             NoWait -> writeKeyword("for update nowait ")
-            is Wait -> writeKeyword("for update wait ${expr.seconds} ")
-            else -> { /* no-op */ }
+            is Wait -> writeKeyword("for update wait ${forUpdate.seconds} ")
+            else -> throw DialectFeatureNotSupportedException("Unsupported ForUpdateOption ${forUpdate::class.java.name}.")
         }
     }
 

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -34,13 +34,17 @@ public open class PostgreSqlDialect : SqlDialect {
 }
 
 /**
- * Postgres Specific ForUpdateOption.
+ * Postgres Specific ForUpdateOption. See docs: https://www.postgresql.org/docs/13/sql-select.html#SQL-FOR-UPDATE-SHARE
  */
 public class PostgresForUpdateOption(
     private val lockStrength: LockStrength,
     private val onLock: OnLock,
     private vararg val tables: Table<*>
 ) : ForUpdateOption {
+
+    /**
+     * Generates SQL locking clause.
+     */
     public fun toLockingClause(): String {
         val lockingClause = StringBuilder(lockStrength.keywords)
         if (tables.isNotEmpty()) {
@@ -50,6 +54,9 @@ public class PostgresForUpdateOption(
         return lockingClause.toString()
     }
 
+    /**
+     * Lock strength.
+     */
     public enum class LockStrength(public val keywords: String) {
         Update("for update "),
         NoKeyUpdate("for no key update "),
@@ -57,6 +64,9 @@ public class PostgresForUpdateOption(
         KeyShare("for key share ")
     }
 
+    /**
+     * Behavior when a lock is detected.
+     */
     public enum class OnLock(public val keywords: String?) {
         Wait(null),
         NoWait("no wait "),

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -20,9 +20,9 @@ import org.ktorm.database.Database
 import org.ktorm.database.SqlDialect
 import org.ktorm.expression.*
 import org.ktorm.schema.IntSqlType
-import org.ktorm.support.postgresql.PostgresForUpdateExpression.NoWait
-import org.ktorm.support.postgresql.PostgresForUpdateExpression.SkipLocked
-import org.ktorm.support.postgresql.PostgresForUpdateExpression.Wait
+import org.ktorm.support.postgresql.PostgresForUpdateOption.NoWait
+import org.ktorm.support.postgresql.PostgresForUpdateOption.SkipLocked
+import org.ktorm.support.postgresql.PostgresForUpdateOption.Wait
 
 /**
  * [SqlDialect] implementation for PostgreSQL database.
@@ -37,13 +37,13 @@ public open class PostgreSqlDialect : SqlDialect {
 /**
  * Postgres Specific ForUpdateExpressions.
  */
-public sealed class PostgresForUpdateExpression : ForUpdateExpression() {
+public sealed class PostgresForUpdateOption : ForUpdateOption {
     /** The generated SQL would be `select ... for update skip locked`. */
-    public object SkipLocked : PostgresForUpdateExpression()
+    public object SkipLocked : PostgresForUpdateOption()
     /** The generated SQL would be `select ... for update nowait`. */
-    public object NoWait : PostgresForUpdateExpression()
+    public object NoWait : PostgresForUpdateOption()
     /** The generated SQL would be `select ... for update wait <seconds>`. */
-    public data class Wait(val seconds: Int) : PostgresForUpdateExpression()
+    public data class Wait(val seconds: Int) : PostgresForUpdateOption()
 }
 
 /**
@@ -52,7 +52,7 @@ public sealed class PostgresForUpdateExpression : ForUpdateExpression() {
 public open class PostgreSqlFormatter(
     database: Database, beautifySql: Boolean, indentSize: Int
 ) : SqlFormatter(database, beautifySql, indentSize) {
-    override fun writeForUpdate(expr: ForUpdateExpression) {
+    override fun writeForUpdate(expr: ForUpdateOption) {
         when (expr) {
             SkipLocked -> writeKeyword("for update skip locked ")
             NoWait -> writeKeyword("for update nowait ")

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeoutException
 class PostgreSqlTest : BaseTest() {
 
     companion object {
-        class KPostgreSqlContainer : PostgreSQLContainer<KPostgreSqlContainer>()
+        class KPostgreSqlContainer : PostgreSQLContainer<KPostgreSqlContainer>("postgres:13-alpine")
 
         @ClassRule
         @JvmField

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -398,7 +398,7 @@ class PostgreSqlTest : BaseTest() {
             val employee = database
                 .sequenceOf(Employees, withReferences = false)
                 .filter { it.id eq 1 }
-                .forUpdate(PostgresForUpdateExpression.NoWait)
+                .forUpdate(PostgresForUpdateOption.NoWait)
                 .first()
 
             val future = Executors.newSingleThreadExecutor().submit {

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -16,6 +16,8 @@ import org.ktorm.schema.ColumnDeclaring
 import org.ktorm.schema.Table
 import org.ktorm.schema.int
 import org.ktorm.schema.varchar
+import org.ktorm.support.postgresql.PostgresForUpdateOption.LockStrength.Update
+import org.ktorm.support.postgresql.PostgresForUpdateOption.OnLock.Wait
 import org.testcontainers.containers.PostgreSQLContainer
 import java.time.LocalDate
 import java.util.concurrent.ExecutionException
@@ -393,12 +395,12 @@ class PostgreSqlTest : BaseTest() {
     }
 
     @Test
-    fun testSelctForUpdate() {
+    fun testSelectForUpdate() {
         database.useTransaction {
             val employee = database
                 .sequenceOf(Employees, withReferences = false)
                 .filter { it.id eq 1 }
-                .forUpdate(PostgresForUpdateOption.NoWait)
+                .forUpdate(PostgresForUpdateOption(lockStrength = Update, onLock = Wait))
                 .first()
 
             val future = Executors.newSingleThreadExecutor().submit {

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -398,7 +398,7 @@ class PostgreSqlTest : BaseTest() {
             val employee = database
                 .sequenceOf(Employees, withReferences = false)
                 .filter { it.id eq 1 }
-                .forUpdate()
+                .forUpdate(PostgresForUpdateExpression.NoWait)
                 .first()
 
             val future = Executors.newSingleThreadExecutor().submit {

--- a/ktorm-support-sqlite/ktorm-support-sqlite.gradle
+++ b/ktorm-support-sqlite/ktorm-support-sqlite.gradle
@@ -3,5 +3,5 @@ dependencies {
     api project(":ktorm-core")
 
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
-    testImplementation "org.xerial:sqlite-jdbc:3.28.0"
+    testImplementation "org.xerial:sqlite-jdbc:3.34.0"
 }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
@@ -18,6 +18,7 @@ package org.ktorm.support.sqlite
 
 import org.ktorm.database.*
 import org.ktorm.expression.ArgumentExpression
+import org.ktorm.expression.ForUpdateOption
 import org.ktorm.expression.QueryExpression
 import org.ktorm.expression.SqlFormatter
 import org.ktorm.schema.IntSqlType
@@ -62,6 +63,9 @@ public open class SQLiteDialect : SqlDialect {
 public open class SQLiteFormatter(
     database: Database, beautifySql: Boolean, indentSize: Int
 ) : SqlFormatter(database, beautifySql, indentSize) {
+    override fun writeForUpdate(forUpdate: ForUpdateOption) {
+        throw DialectFeatureNotSupportedException("SQLite does not support SELECT ... FOR UPDATE.")
+    }
 
     override fun writePagination(expr: QueryExpression) {
         newLine(Indentation.SAME)

--- a/ktorm-support-sqlserver/ktorm-support-sqlserver.gradle
+++ b/ktorm-support-sqlserver/ktorm-support-sqlserver.gradle
@@ -4,5 +4,5 @@ dependencies {
     api "com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8"
 
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
-    testImplementation "org.testcontainers:mssqlserver:1.11.3"
+    testImplementation "org.testcontainers:mssqlserver:1.15.1"
 }

--- a/ktorm-support-sqlserver/src/main/kotlin/org/ktorm/support/sqlserver/SqlServerDialect.kt
+++ b/ktorm-support-sqlserver/src/main/kotlin/org/ktorm/support/sqlserver/SqlServerDialect.kt
@@ -67,7 +67,7 @@ public open class SqlServerFormatter(
         if (expr.offset == null && expr.limit == null) {
             return super.visitQuery(expr)
         }
-        if (expr is SelectExpression && expr.forUpdate != null) {
+        if (expr is SelectExpression && expr.forUpdate != ForUpdateOption.None) {
             throw DialectFeatureNotSupportedException("SELECT FOR UPDATE not supported when using offset/limit params.")
         }
 

--- a/ktorm-support-sqlserver/src/main/kotlin/org/ktorm/support/sqlserver/SqlServerDialect.kt
+++ b/ktorm-support-sqlserver/src/main/kotlin/org/ktorm/support/sqlserver/SqlServerDialect.kt
@@ -20,6 +20,7 @@ import org.ktorm.database.Database
 import org.ktorm.database.DialectFeatureNotSupportedException
 import org.ktorm.database.SqlDialect
 import org.ktorm.expression.*
+import org.ktorm.support.sqlserver.SqlServerForUpdateOption.ForUpdate
 
 /**
  * [SqlDialect] implementation for Microsoft SqlServer database.
@@ -29,6 +30,14 @@ public open class SqlServerDialect : SqlDialect {
     override fun createSqlFormatter(database: Database, beautifySql: Boolean, indentSize: Int): SqlFormatter {
         return SqlServerFormatter(database, beautifySql, indentSize)
     }
+}
+
+/**
+ * SqlServer Specific ForUpdateOptions.
+ */
+public sealed class SqlServerForUpdateOption : ForUpdateOption {
+    /** The generated SQL would be `select ... for update`. */
+    public object ForUpdate : SqlServerForUpdateOption()
 }
 
 /**
@@ -45,11 +54,20 @@ public open class SqlServerFormatter(
         }
     }
 
+    override fun writeForUpdate(forUpdate: ForUpdateOption) {
+        when (forUpdate) {
+            ForUpdate -> writeKeyword("for update ")
+            else -> throw DialectFeatureNotSupportedException(
+                "Unsupported ForUpdateOption ${forUpdate::class.java.name}."
+            )
+        }
+    }
+
     override fun visitQuery(expr: QueryExpression): QueryExpression {
         if (expr.offset == null && expr.limit == null) {
             return super.visitQuery(expr)
         }
-        if (expr is SelectExpression && expr.forUpdate) {
+        if (expr is SelectExpression && expr.forUpdate != null) {
             throw DialectFeatureNotSupportedException("SELECT FOR UPDATE not supported when using offset/limit params.")
         }
 

--- a/ktorm-support-sqlserver/src/test/kotlin/org/ktorm/support/sqlserver/SqlServerTest.kt
+++ b/ktorm-support-sqlserver/src/test/kotlin/org/ktorm/support/sqlserver/SqlServerTest.kt
@@ -37,7 +37,7 @@ class SqlServerTest : BaseTest() {
         const val ID_3 = 3
         const val ID_4 = 4
 
-        class KSqlServerContainer : MSSQLServerContainer<KSqlServerContainer>()
+        class KSqlServerContainer : MSSQLServerContainer<KSqlServerContainer>("mcr.microsoft.com/mssql/server:2017-CU12")
 
         @ClassRule
         @JvmField


### PR DESCRIPTION
Implements per-dialect `FOR UPDATE` options. PostgreSQL and MySQL are fully implemented. Oracle and MS SqlServer might have additional options that I'm not aware of. Initial discussion happened in PR #238.