### PR TITLE
Adding explicit do-nothing to on-conflict clauses

### DIFF
--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/BulkInsert.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/BulkInsert.kt
@@ -26,6 +26,14 @@ import org.ktorm.expression.SqlExpression
 import org.ktorm.expression.TableExpression
 import org.ktorm.schema.BaseTable
 import org.ktorm.schema.Column
+import java.util.*
+import kotlin.collections.ArrayList
+
+// We leave some prepared statement parameters reserved for the query dialect building process
+private const val RESERVED_SQL_EXPR_BATCH_SIZE = 100
+
+// Max number of assignments we allow per batch in Postgresql (Max size as defined by Postgresql - reserved)
+private const val MAX_SQL_EXPR_BATCH_SIZE = Short.MAX_VALUE - RESERVED_SQL_EXPR_BATCH_SIZE
 
 /**
  * Bulk insert expression, represents a bulk insert statement in PostgreSQL.
@@ -45,8 +53,9 @@ import org.ktorm.schema.Column
 public data class BulkInsertExpression(
     val table: TableExpression,
     val assignments: List<List<ColumnAssignmentExpression<*>>>,
-    val conflictColumns: List<ColumnExpression<*>> = emptyList(),
+    val conflictColumns: List<ColumnExpression<*>>? = null,
     val updateAssignments: List<ColumnAssignmentExpression<*>> = emptyList(),
+    val returningColumns: List<ColumnExpression<*>> = emptyList(),
     override val isLeafNode: Boolean = false,
     override val extraProperties: Map<String, Any> = emptyMap()
 ) : SqlExpression()
@@ -92,9 +101,26 @@ public data class BulkInsertExpression(
 public fun <T : BaseTable<*>> Database.bulkInsert(
     table: T, block: BulkInsertStatementBuilder<T>.(T) -> Unit
 ): Int {
+    var affectedTotal = 0
+
     val builder = BulkInsertStatementBuilder(table).apply { block(table) }
-    val expression = BulkInsertExpression(table.asExpression(), builder.assignments)
-    return executeUpdate(expression)
+
+    if (builder.assignments.isEmpty()) return 0
+
+    val execute: (List<List<ColumnAssignmentExpression<*>>>) -> Unit = { assignments ->
+        val expression = BulkInsertExpression(
+            table = table.asExpression(),
+            assignments = assignments
+        )
+
+        val total = executeUpdate(expression)
+
+        affectedTotal += total
+    }
+
+    executeQueryInBatches(builder, execute)
+
+    return affectedTotal
 }
 
 /**
@@ -144,24 +170,42 @@ public fun <T : BaseTable<*>> Database.bulkInsert(
 public fun <T : BaseTable<*>> Database.bulkInsertOrUpdate(
     table: T, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
 ): Int {
+    var affectedTotal = 0
+
     val builder = BulkInsertOrUpdateStatementBuilder(table).apply { block(table) }
+
+    if (builder.assignments.isEmpty()) return 0
 
     val conflictColumns = builder.conflictColumns.ifEmpty { table.primaryKeys }
     if (conflictColumns.isEmpty()) {
         val msg =
             "Table '$table' doesn't have a primary key, " +
-            "you must specify the conflict columns when calling onConflict(col) { .. }"
+                "you must specify the conflict columns when calling onConflict(col) { .. }"
         throw IllegalStateException(msg)
     }
 
-    val expression = BulkInsertExpression(
-        table = table.asExpression(),
-        assignments = builder.assignments,
-        conflictColumns = conflictColumns.map { it.asExpression() },
-        updateAssignments = builder.updateAssignments
-    )
+    if (!builder.explicitlyDoNothing && builder.updateAssignments.isEmpty()) {
+        val msg = "You cannot leave a on-conflict clause empty! If you desire no update action at all" +
+            " you must explicitly invoke `doNothing()`"
+        throw IllegalStateException(msg)
+    }
 
-    return executeUpdate(expression)
+    val execute: (List<List<ColumnAssignmentExpression<*>>>) -> Unit = { assignments ->
+        val expression = BulkInsertExpression(
+            table = table.asExpression(),
+            assignments = assignments,
+            conflictColumns = conflictColumns.map { it.asExpression() },
+            updateAssignments = if (builder.explicitlyDoNothing) emptyList() else builder.updateAssignments,
+        )
+
+        val total = executeUpdate(expression)
+
+        affectedTotal += total
+    }
+
+    executeQueryInBatches(builder, execute)
+
+    return affectedTotal
 }
 
 /**
@@ -195,31 +239,493 @@ public class BulkInsertOrUpdateStatementBuilder<T : BaseTable<*>>(table: T) : Bu
     internal val updateAssignments = ArrayList<ColumnAssignmentExpression<*>>()
     internal val conflictColumns = ArrayList<Column<*>>()
 
+    internal var explicitlyDoNothing: Boolean = false
+
     /**
      * Specify the update assignments while any key conflict exists.
      */
-    public fun onConflict(vararg columns: Column<*>, block: BulkInsertOrUpdateOnConflictClauseBuilder.() -> Unit) {
-        val builder = BulkInsertOrUpdateOnConflictClauseBuilder().apply(block)
+    public fun onConflict(vararg columns: Column<*>, block: InsertOrUpdateOnConflictClauseBuilder.() -> Unit) {
+        val builder = InsertOrUpdateOnConflictClauseBuilder().apply(block)
+
+        explicitlyDoNothing = builder.explicitlyDoNothing
+
         updateAssignments += builder.assignments
+
         conflictColumns += columns
     }
 }
 
 /**
- * DSL builder for bulk insert or update on conflict clause.
+ * Construct a bulk insert expression in the given closure, then execute it and return the effected row count.
+ *
+ * The usage is almost the same as [batchInsert], but this function is implemented by generating a special SQL
+ * using PostgreSQL's bulk insert syntax, instead of based on JDBC batch operations. For this reason, its performance
+ * is much better than [batchInsert].
+ *
+ * The generated SQL is like: `insert into table (column1, column2) values (?, ?), (?, ?), (?, ?)...
+ * returning id`.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Employees.id) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @param returningColumn the column to return
+ * @return the returning column value.
+ * @see batchInsert
  */
-@KtormDsl
-public class BulkInsertOrUpdateOnConflictClauseBuilder : PostgreSqlAssignmentsBuilder() {
+public fun <T : BaseTable<*>, R : Any> Database.bulkInsertReturning(
+    table: T,
+    returningColumn: Column<R>,
+    block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<R?> {
+    val (_, rowSet) = this.bulkInsertReturningAux(
+        table,
+        listOf(returningColumn),
+        block
+    )
 
-    /**
-     * Reference the 'EXCLUDED' table in a ON CONFLICT clause.
-     */
-    public fun <T : Any> excluded(column: Column<T>): ColumnExpression<T> {
-        // excluded.name
-        return ColumnExpression(
-            table = TableExpression(name = "excluded"),
-            name = column.name,
-            sqlType = column.sqlType
+    return rowSet.asIterable().map { row ->
+        returningColumn.sqlType.getResult(row, 1)
+    }
+}
+
+/**
+ * Construct a bulk insert expression in the given closure, then execute it and return the effected row count.
+ *
+ * The usage is almost the same as [batchInsert], but this function is implemented by generating a special SQL
+ * using PostgreSQL's bulk insert syntax, instead of based on JDBC batch operations. For this reason, its performance
+ * is much better than [batchInsert].
+ *
+ * The generated SQL is like: `insert into table (column1, column2) values (?, ?), (?, ?), (?, ?)...
+ * returning id, job`.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @param returningColumns the columns to return
+ * @return the returning columns' values.
+ * @see batchInsert
+ */
+public fun <T : BaseTable<*>, R1 : Any, R2 : Any> Database.bulkInsertReturning(
+    table: T,
+    returningColumns: Pair<Column<R1>, Column<R2>>,
+    block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<Pair<R1?, R2?>> {
+    val (_, rowSet) = this.bulkInsertReturningAux(
+        table,
+        returningColumns.toList(),
+        block
+    )
+
+    return rowSet.asIterable().map { row ->
+        Pair(
+            returningColumns.first.sqlType.getResult(row, 1),
+            returningColumns.second.sqlType.getResult(row, 2)
         )
+    }
+}
+
+/**
+ * Construct a bulk insert expression in the given closure, then execute it and return the effected row count.
+ *
+ * The usage is almost the same as [batchInsert], but this function is implemented by generating a special SQL
+ * using PostgreSQL's bulk insert syntax, instead of based on JDBC batch operations. For this reason, its performance
+ * is much better than [batchInsert].
+ *
+ * The generated SQL is like: `insert into table (column1, column2) values (?, ?), (?, ?), (?, ?)...
+ * returning id, job, salary`.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @param returningColumns the columns to return
+ * @return the returning columns' values.
+ * @see batchInsert
+ */
+public fun <T : BaseTable<*>, R1 : Any, R2 : Any, R3 : Any> Database.bulkInsertReturning(
+    table: T,
+    returningColumns: Triple<Column<R1>, Column<R2>, Column<R3>>,
+    block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<Triple<R1?, R2?, R3?>> {
+    val (_, rowSet) = this.bulkInsertReturningAux(
+        table,
+        returningColumns.toList(),
+        block
+    )
+
+    return rowSet.asIterable().map { row ->
+        var i = 0
+        Triple(
+            returningColumns.first.sqlType.getResult(row, ++i),
+            returningColumns.second.sqlType.getResult(row, ++i),
+            returningColumns.third.sqlType.getResult(row, ++i)
+        )
+    }
+}
+
+private fun <T : BaseTable<*>> Database.bulkInsertReturningAux(
+    table: T,
+    returningColumns: List<Column<*>>,
+    block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): Pair<Int, CompositeCachedRowSet> {
+    var affectedTotal = 0
+    val cachedRowSets = CompositeCachedRowSet()
+
+    val builder = BulkInsertStatementBuilder(table).apply { block(table) }
+
+    if (builder.assignments.isEmpty()) return Pair(0, CompositeCachedRowSet())
+
+    val execute: (List<List<ColumnAssignmentExpression<*>>>) -> Unit = { assignments ->
+        val expression = BulkInsertExpression(
+            table.asExpression(),
+            assignments,
+            returningColumns = returningColumns.map { it.asExpression() }
+        )
+
+        val (total, rows) = executeUpdateAndRetrieveKeys(expression)
+
+        affectedTotal += total
+        cachedRowSets.add(rows)
+    }
+
+    executeQueryInBatches(builder, execute)
+
+    return Pair(affectedTotal, cachedRowSets)
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * and automatically performs updates if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Pair(Employees.id, Employees.name)) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job, ...
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param block the DSL block used to construct the expression.
+ * @param returningColumn the column to return
+ * @return the returning column value.
+ * @see bulkInsert
+ */
+public fun <T : BaseTable<*>, R : Any> Database.bulkInsertOrUpdateReturning(
+    table: T,
+    returningColumn: Column<R>,
+    block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<R?> {
+    val (_, rowSet) = this.bulkInsertOrUpdateReturningAux(
+        table,
+        listOf(returningColumn),
+        block
+    )
+
+    return rowSet.asIterable().map { row ->
+        returningColumn.sqlType.getResult(row, 1)
+    }
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * and automatically performs updates if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Pair(Employees.id, Employees.name)) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job, ...
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param block the DSL block used to construct the expression.
+ * @param returningColumns the column to return
+ * @return the returning columns' values.
+ * @see bulkInsert
+ */
+public fun <T : BaseTable<*>, R1 : Any, R2 : Any> Database.bulkInsertOrUpdateReturning(
+    table: T,
+    returningColumns: Pair<Column<R1>, Column<R2>>,
+    block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<Pair<R1?, R2?>> {
+    val (_, rowSet) = this.bulkInsertOrUpdateReturningAux(
+        table,
+        returningColumns.toList(),
+        block
+    )
+
+    return rowSet.asIterable().map { row ->
+        Pair(
+            returningColumns.first.sqlType.getResult(row, 1),
+            returningColumns.second.sqlType.getResult(row, 2)
+        )
+    }
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * and automatically performs updates if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Pair(Employees.id, Employees.name, Employees.salary)) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job, ...
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param block the DSL block used to construct the expression.
+ * @param returningColumns the column to return
+ * @return the returning columns' values.
+ * @see bulkInsert
+ */
+public fun <T : BaseTable<*>, R1 : Any, R2 : Any, R3 : Any> Database.bulkInsertOrUpdateReturning(
+    table: T,
+    returningColumns: Triple<Column<R1>, Column<R2>, Column<R3>>,
+    block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<Triple<R1?, R2?, R3?>> {
+    val (_, rowSet) = this.bulkInsertOrUpdateReturningAux(
+        table,
+        returningColumns.toList(),
+        block
+    )
+
+    return rowSet.asIterable().map { row ->
+        var i = 0
+        Triple(
+            returningColumns.first.sqlType.getResult(row, ++i),
+            returningColumns.second.sqlType.getResult(row, ++i),
+            returningColumns.third.sqlType.getResult(row, ++i)
+        )
+    }
+}
+
+private fun <T : BaseTable<*>> Database.bulkInsertOrUpdateReturningAux(
+    table: T,
+    returningColumns: List<Column<*>>,
+    block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): Pair<Int, CompositeCachedRowSet> {
+    var affectedTotal = 0
+    val cachedRowSets = CompositeCachedRowSet()
+
+    val builder = BulkInsertOrUpdateStatementBuilder(table).apply { block(table) }
+
+    if (builder.assignments.isEmpty()) return Pair(0, CompositeCachedRowSet())
+
+    val conflictColumns = builder.conflictColumns.ifEmpty { table.primaryKeys }
+    if (conflictColumns.isEmpty()) {
+        val msg =
+            "Table '$table' doesn't have a primary key, " +
+                "you must specify the conflict columns when calling onConflict(col) { .. }"
+        throw IllegalStateException(msg)
+    }
+
+    if (!builder.explicitlyDoNothing && builder.updateAssignments.isEmpty()) {
+        val msg = "You cannot leave a on-conflict clause empty! If you desire no update action at all" +
+            " you must explicitly invoke `doNothing()`"
+        throw IllegalStateException(msg)
+    }
+
+    val execute: (List<List<ColumnAssignmentExpression<*>>>) -> Unit = { assignments ->
+        val expression = BulkInsertExpression(
+            table = table.asExpression(),
+            assignments = assignments,
+            conflictColumns = conflictColumns.map { it.asExpression() },
+            updateAssignments = if (builder.explicitlyDoNothing) emptyList() else builder.updateAssignments,
+            returningColumns = returningColumns.map { it.asExpression() }
+        )
+
+        val (total, rows) = executeUpdateAndRetrieveKeys(expression)
+
+        affectedTotal += total
+        cachedRowSets.add(rows)
+    }
+
+    executeQueryInBatches(builder, execute)
+
+    return Pair(affectedTotal, cachedRowSets)
+}
+
+private fun <T : BaseTable<*>> executeQueryInBatches(
+    builder: BulkInsertStatementBuilder<T>,
+    execute: (List<List<ColumnAssignmentExpression<*>>>) -> Unit
+) {
+    var batchAssignmentCount = 0
+    val currentBatch = LinkedList<List<ColumnAssignmentExpression<*>>>()
+    builder.assignments.forEach { assignments ->
+        assignments.size.let { size ->
+            if (size > MAX_SQL_EXPR_BATCH_SIZE) {
+                throw IllegalArgumentException(
+                    "The maximum number of assignments per item is $MAX_SQL_EXPR_BATCH_SIZE, but $size detected!"
+                )
+            }
+
+            currentBatch.add(assignments)
+            batchAssignmentCount += size
+        }
+
+        if (batchAssignmentCount >= MAX_SQL_EXPR_BATCH_SIZE) {
+            execute(currentBatch)
+            currentBatch.clear()
+            batchAssignmentCount = 0
+        }
+    }
+    if (currentBatch.isNotEmpty()) {
+        execute(currentBatch)
     }
 }

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/CompositeCachedRowSet.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/CompositeCachedRowSet.kt
@@ -20,22 +20,23 @@ import org.ktorm.database.CachedRowSet
 import java.util.*
 
 /**
- * To document.
+ * Utility class that stores the resulting CachedRowSet from
+ * multiple queries, but abstract their iteration as if they were
+ * a single CachedRowSet.
  */
 public class CompositeCachedRowSet {
     private val resultSets = LinkedList<CachedRowSet>()
 
     /**
-     * To document.
-     * @param rs todo
-     * @return todo
+     * Adds a CachedRowSet to the composite group.
+     * @param rs the new CachedRowSet
      */
     public fun add(rs: CachedRowSet) {
         resultSets.add(rs)
     }
 
     /**
-     * To document.
+     * Returns the iterator for this composite.
      */
     @Suppress("IteratorHasNextCallsNextMethod")
     public operator fun iterator(): Iterator<CachedRowSet> = object : Iterator<CachedRowSet> {
@@ -62,7 +63,7 @@ public class CompositeCachedRowSet {
     }
 
     /**
-     * To document.
+     * Returns the iterator for this composite.
      */
     public fun asIterable(): Iterable<CachedRowSet> {
         return Iterable { iterator() }

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/CompositeCachedRowSet.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/CompositeCachedRowSet.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.support.postgresql
+
+import org.ktorm.database.CachedRowSet
+import java.util.*
+
+/**
+ * To document.
+ */
+public class CompositeCachedRowSet {
+    private val resultSets = LinkedList<CachedRowSet>()
+
+    /**
+     * To document.
+     * @param rs todo
+     * @return todo
+     */
+    public fun add(rs: CachedRowSet) {
+        resultSets.add(rs)
+    }
+
+    /**
+     * To document.
+     */
+    @Suppress("IteratorHasNextCallsNextMethod")
+    public operator fun iterator(): Iterator<CachedRowSet> = object : Iterator<CachedRowSet> {
+        private var cursor = 0
+        private var hasNext: Boolean? = null
+
+        override fun hasNext(): Boolean {
+            val hasNext = (cursor < resultSets.size && resultSets[cursor].next()).also { hasNext = it }
+
+            if (!hasNext) {
+                return ++cursor < resultSets.size && hasNext()
+            }
+
+            return hasNext
+        }
+
+        override fun next(): CachedRowSet {
+            return if (hasNext ?: hasNext()) {
+                resultSets[cursor].also { hasNext = null }
+            } else {
+                throw NoSuchElementException()
+            }
+        }
+    }
+
+    /**
+     * To document.
+     */
+    public fun asIterable(): Iterable<CachedRowSet> {
+        return Iterable { iterator() }
+    }
+}

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/InsertOrUpdate.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/InsertOrUpdate.kt
@@ -92,6 +92,12 @@ public fun <T : BaseTable<*>> Database.insertOrUpdate(
         throw IllegalStateException(msg)
     }
 
+    if (!builder.explicitlyDoNothing && builder.updateAssignments.isEmpty()) {
+        val msg = "You cannot leave a on-conflict clause empty! If you desire no update action at all" +
+            " you must explicitly invoke `doNothing()`"
+        throw IllegalStateException(msg)
+    }
+
     val expression = InsertOrUpdateExpression(
         table = table.asExpression(),
         assignments = builder.assignments,
@@ -346,6 +352,12 @@ private fun <T : BaseTable<*>> Database.insertOrUpdateReturningAux(
         val msg =
             "Table '$table' doesn't have a primary key, " +
                 "you must specify the conflict columns when calling onDuplicateKey(col) { .. }"
+        throw IllegalStateException(msg)
+    }
+
+    if (!builder.explicitlyDoNothing && builder.updateAssignments.isEmpty()) {
+        val msg = "You cannot leave a on-conflict clause empty! If you desire no update action at all" +
+            " you must explicitly invoke `doNothing()`"
         throw IllegalStateException(msg)
     }
 

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/InsertOrUpdate.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/InsertOrUpdate.kt
@@ -16,7 +16,9 @@
 
 package org.ktorm.support.postgresql
 
+import org.ktorm.database.CachedRowSet
 import org.ktorm.database.Database
+import org.ktorm.database.asIterable
 import org.ktorm.dsl.AssignmentsBuilder
 import org.ktorm.dsl.KtormDsl
 import org.ktorm.expression.ColumnAssignmentExpression
@@ -38,8 +40,9 @@ import org.ktorm.schema.Column
 public data class InsertOrUpdateExpression(
     val table: TableExpression,
     val assignments: List<ColumnAssignmentExpression<*>>,
-    val conflictColumns: List<ColumnExpression<*>> = emptyList(),
+    val conflictColumns: List<ColumnExpression<*>>? = null,
     val updateAssignments: List<ColumnAssignmentExpression<*>> = emptyList(),
+    val returningColumns: List<ColumnExpression<*>> = emptyList(),
     override val isLeafNode: Boolean = false,
     override val extraProperties: Map<String, Any> = emptyMap()
 ) : SqlExpression()
@@ -85,7 +88,7 @@ public fun <T : BaseTable<*>> Database.insertOrUpdate(
     if (conflictColumns.isEmpty()) {
         val msg =
             "Table '$table' doesn't have a primary key, " +
-            "you must specify the conflict columns when calling onConflict(col) { .. }"
+                "you must specify the conflict columns when calling onConflict(col) { .. }"
         throw IllegalStateException(msg)
     }
 
@@ -93,7 +96,7 @@ public fun <T : BaseTable<*>> Database.insertOrUpdate(
         table = table.asExpression(),
         assignments = builder.assignments,
         conflictColumns = conflictColumns.map { it.asExpression() },
-        updateAssignments = builder.updateAssignments
+        updateAssignments = if (builder.explicitlyDoNothing) emptyList() else builder.updateAssignments,
     )
 
     return executeUpdate(expression)
@@ -119,6 +122,8 @@ public class InsertOrUpdateStatementBuilder : PostgreSqlAssignmentsBuilder() {
     internal val updateAssignments = ArrayList<ColumnAssignmentExpression<*>>()
     internal val conflictColumns = ArrayList<Column<*>>()
 
+    internal var explicitlyDoNothing: Boolean = false
+
     /**
      * Specify the update assignments while any key conflict exists.
      */
@@ -133,9 +138,224 @@ public class InsertOrUpdateStatementBuilder : PostgreSqlAssignmentsBuilder() {
     /**
      * Specify the update assignments while any key conflict exists.
      */
-    public fun onConflict(vararg columns: Column<*>, block: AssignmentsBuilder.() -> Unit) {
-        val builder = PostgreSqlAssignmentsBuilder().apply(block)
+    public fun onConflict(vararg columns: Column<*>, block: InsertOrUpdateOnConflictClauseBuilder.() -> Unit) {
+        val builder = InsertOrUpdateOnConflictClauseBuilder().apply(block)
+
+        explicitlyDoNothing = builder.explicitlyDoNothing
+
         updateAssignments += builder.assignments
+
         conflictColumns += columns
     }
+}
+
+/**
+ * DSL builder for insert or update on conflict clause.
+ */
+@KtormDsl
+public class InsertOrUpdateOnConflictClauseBuilder : PostgreSqlAssignmentsBuilder() {
+    internal var explicitlyDoNothing: Boolean = false
+
+    /**
+     * Explicitly tells ktorm to ignore any on-conflict errors and continue insertion.
+     */
+    public fun doNothing() {
+        this.explicitlyDoNothing = true
+    }
+
+    /**
+     * Reference the 'EXCLUDED' table in a ON CONFLICT clause.
+     */
+    public fun <T : Any> excluded(column: Column<T>): ColumnExpression<T> {
+        // excluded.name
+        return ColumnExpression(
+            table = TableExpression(name = "excluded"),
+            name = column.name,
+            sqlType = column.sqlType
+        )
+    }
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, and automatically
+ * performs an update if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.insertOrUpdateReturning(Employees, Employees.id) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onDuplicateKey {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id) values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returningColumn the column to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning column value.
+ */
+public fun <T : BaseTable<*>, R : Any> Database.insertOrUpdateReturning(
+    table: T,
+    returningColumn: Column<R>,
+    block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): R? {
+    val (_, rowSet) = this.insertOrUpdateReturningAux(
+        table,
+        listOfNotNull(returningColumn),
+        block
+    )
+
+    return rowSet.asIterable().map { row ->
+        returningColumn.sqlType.getResult(row, 1)
+    }.first()
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, and automatically
+ * performs an update if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.insertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onDuplicateKey {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id) values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returningColumns the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, R1 : Any, R2 : Any> Database.insertOrUpdateReturning(
+    table: T,
+    returningColumns: Pair<Column<R1>, Column<R2>>,
+    block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): Pair<R1?, R2?> {
+    val (_, rowSet) = this.insertOrUpdateReturningAux(
+        table,
+        returningColumns.toList(),
+        block
+    )
+
+    return rowSet.asIterable().map { row ->
+        Pair(
+            returningColumns.first.sqlType.getResult(row, 1),
+            returningColumns.second.sqlType.getResult(row, 2)
+        )
+    }.first()
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, and automatically
+ * performs an update if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.insertOrUpdateReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onDuplicateKey {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id) values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returningColumns the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, R1 : Any, R2 : Any, R3 : Any> Database.insertOrUpdateReturning(
+    table: T,
+    returningColumns: Triple<Column<R1>, Column<R2>, Column<R3>>,
+    block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): Triple<R1?, R2?, R3?> {
+    val (_, rowSet) = this.insertOrUpdateReturningAux(
+        table,
+        returningColumns.toList(),
+        block
+    )
+
+    return rowSet.asIterable().map { row ->
+        var i = 0
+        Triple(
+            returningColumns.first.sqlType.getResult(row, ++i),
+            returningColumns.second.sqlType.getResult(row, ++i),
+            returningColumns.third.sqlType.getResult(row, ++i)
+        )
+    }.first()
+}
+
+private fun <T : BaseTable<*>> Database.insertOrUpdateReturningAux(
+    table: T,
+    returningColumns: List<Column<*>>,
+    block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): Pair<Int, CachedRowSet> {
+    val builder = InsertOrUpdateStatementBuilder().apply { block(table) }
+
+    val primaryKeys = table.primaryKeys
+    if (primaryKeys.isEmpty() && builder.conflictColumns.isEmpty()) {
+        val msg =
+            "Table '$table' doesn't have a primary key, " +
+                "you must specify the conflict columns when calling onDuplicateKey(col) { .. }"
+        throw IllegalStateException(msg)
+    }
+
+    val expression = InsertOrUpdateExpression(
+        table = table.asExpression(),
+        assignments = builder.assignments,
+        conflictColumns = builder.conflictColumns.ifEmpty { primaryKeys }.map { it.asExpression() },
+        updateAssignments = if (builder.explicitlyDoNothing) emptyList() else builder.updateAssignments,
+        returningColumns = returningColumns.map { it.asExpression() }
+    )
+
+    return executeUpdateAndRetrieveKeys(expression)
 }

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import kotlin.math.roundToInt
 
 /**
  * Created by vince on Feb 13, 2019.
@@ -162,6 +163,73 @@ class PostgreSqlTest : BaseTest() {
     }
 
     @Test
+    fun testInsertOrUpdateReturning() {
+        database.insertOrUpdateReturning(
+            Employees,
+            Employees.id
+        ) {
+            set(it.id, 1009)
+            set(it.name, "pedro")
+            set(it.job, "engineer")
+            set(it.salary, 1500)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+
+            onDuplicateKey {
+                set(it.salary, it.salary + 900)
+            }
+        }.let { createdId ->
+            assert(createdId == 1009)
+        }
+
+        database.insertOrUpdateReturning(
+            Employees,
+            Pair(
+                Employees.id,
+                Employees.name
+            )
+        ) {
+            set(it.id, 1001)
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+
+            onDuplicateKey {
+                set(it.salary, it.salary + 900)
+            }
+        }.let { (createdId, createdName) ->
+            assert(createdId == 1001)
+            assert(createdName == "vince")
+        }
+
+        database.insertOrUpdateReturning(
+            Employees,
+            Triple(
+                Employees.id,
+                Employees.name,
+                Employees.salary
+            )
+        ) {
+            set(it.id, 1001)
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+
+            onDuplicateKey(it.id) {
+                set(it.salary, it.salary + 900)
+            }
+        }.let { (createdId, createdName, createdSalary) ->
+            assert(createdId == 1001)
+            assert(createdName == "vince")
+            assert(createdSalary == 1900L)
+        }
+    }
+
+    @Test
     fun testBulkInsertOrUpdate() {
         database.bulkInsertOrUpdate(Employees) {
             item {
@@ -197,6 +265,189 @@ class PostgreSqlTest : BaseTest() {
             assert(it.job == "engineer")
             assert(it.department.id == 2)
             assert(it.salary == 1000L)
+        }
+    }
+
+    @Test
+    fun testBulkInsertWithUpdate() {
+        // Make sure we are creating new entries in the table (avoid colliding with existing test data)
+        val id1 = (Math.random() * 10000).roundToInt()
+        val id2 = (Math.random() * 10000).roundToInt()
+
+        val bulkInsertWithUpdate = { onDuplicateKeyDoNothing: Boolean ->
+            database.bulkInsertOrUpdate(Employees) {
+                item {
+                    set(it.id, id1)
+                    set(it.name, "vince")
+                    set(it.job, "engineer")
+                    set(it.salary, 1000)
+                    set(it.hireDate, LocalDate.now())
+                    set(it.departmentId, 1)
+                }
+                item {
+                    set(it.id, id2)
+                    set(it.name, "vince")
+                    set(it.job, "engineer")
+                    set(it.salary, 1000)
+                    set(it.hireDate, LocalDate.now())
+                    set(it.departmentId, 1)
+                }
+                onConflict(Employees.id) {
+                    if (!onDuplicateKeyDoNothing)
+                        set(it.salary, it.salary + 900)
+                    else
+                        doNothing()
+                }
+            }
+        }
+
+        bulkInsertWithUpdate(false)
+        assert(database.employees.find { it.id eq id1 }!!.salary == 1000L)
+        assert(database.employees.find { it.id eq id2 }!!.salary == 1000L)
+
+        bulkInsertWithUpdate(false)
+        assert(database.employees.find { it.id eq id1 }!!.salary == 1900L)
+        assert(database.employees.find { it.id eq id2 }!!.salary == 1900L)
+
+        bulkInsertWithUpdate(true)
+        assert(database.employees.find { it.id eq id1 }!!.salary == 1900L)
+        assert(database.employees.find { it.id eq id2 }!!.salary == 1900L)
+    }
+
+    @Test
+    fun testBulkInsertReturning() {
+        database.bulkInsertReturning(
+            Employees,
+            Employees.id
+        ) {
+            item {
+                set(it.id, 10001)
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.id, 50001)
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+        }.let { createdIds ->
+            assert(createdIds.size == 2)
+            assert(
+                listOf(
+                    10001,
+                    50001
+                ) == createdIds
+            )
+        }
+
+        database.bulkInsertReturning(
+            Employees,
+            Pair(
+                Employees.id,
+                Employees.name
+            )
+        ) {
+            item {
+                set(it.id, 10002)
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.id, 50002)
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+        }.let { created ->
+            assert(
+                listOf(
+                    (10002 to "vince"),
+                    (50002 to "vince")
+                ) == created
+            )
+        }
+
+        database.bulkInsertReturning(
+            Employees,
+            Triple(
+                Employees.id,
+                Employees.name,
+                Employees.job
+            )
+        ) {
+            item {
+                set(it.id, 10003)
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.id, 50003)
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+        }.let { created ->
+            assert(
+                listOf(
+                    Triple(10003, "vince", "trainee"),
+                    Triple(50003, "vince", "engineer")
+                ) == created
+            )
+        }
+    }
+
+    @Test
+    fun testBulkInsertOrUpdateReturning() {
+        database.bulkInsertOrUpdateReturning(
+            Employees,
+            Pair(
+                Employees.id,
+                Employees.job
+            )
+        ) {
+            item {
+                set(it.id, 1000)
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.id, 5000)
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            onConflict(it.id) {
+                set(it.departmentId, excluded(it.departmentId))
+                set(it.salary, it.salary + 1000)
+            }
+        }.let { created ->
+            assert(
+                listOf(
+                    Pair(1000, "trainee"),
+                    Pair(5000, "engineer")
+                ) == created
+            )
         }
     }
 


### PR DESCRIPTION
@vincentlauvlwj 

This PR allows for using `doNothing()` within `onConflict` clauses in Postgresql extension methods.

Additionally I improved the bulk operations by allowing it to batch an infinite amount of `items` by using chunks internally. Before that ktorm was capped to 32767 (`Short.MAX_VALUE`) parameters as per Postgres specification, which would result in a very limited number of items. These bulk operations are now ready to handle millions if not billions of items.