### PR TITLE
通过数据类简易方便的创建 BaseTable 对象

### DIFF
--- a/ktorm-autotable/ktorm-autotable.gradle
+++ b/ktorm-autotable/ktorm-autotable.gradle
@@ -1,0 +1,10 @@
+
+dependencies {
+    api project(":ktorm-core")
+
+    api "org.reflections:reflections:0.9.9"
+
+    testImplementation project(path: ":ktorm-core", configuration: "testOutput")
+    //testImplementation project(":ktorm-jackson")
+    //testImplementation "org.testcontainers:mysql:1.15.1"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/AutoTable.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/AutoTable.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable
+
+import org.ktorm.autotable.annotations.TableField
+import org.ktorm.dsl.QueryRowSet
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+import kotlin.reflect.KProperty0
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.javaField
+
+/**
+ * Simple create an ktorm BaseTable by entity class.
+ */
+@Suppress("unused", "LabeledExpression")
+public open class AutoTable<T : Any> private constructor(
+    entityClass: KClass<T>,
+    tableName: String = entityClass.tableName,
+    alias: String? = null,
+    catalog: String? = null,
+    schema: String? = null,
+    private val unsafe: Boolean = true,
+    private val fieldMap: Map<String, KProperty1<out T, *>>,
+    private val fieldNameColumnMap: MutableMap<String, Column<*>> = HashMap(),
+) : BaseTable<T>(tableName, alias, catalog, schema, entityClass) {
+    public constructor(
+        entityClass: KClass<T>,
+        tableName: String = entityClass.tableName,
+        alias: String? = null,
+        catalog: String? = null,
+        schema: String? = null,
+        unsafe: Boolean = true,
+    ) : this(
+        entityClass, tableName, alias, catalog, schema, unsafe,
+        entityClass.memberProperties.associateBy { it.simpTableField },
+    ) {
+        entityClass.memberProperties.forEach {
+            val field = it.javaField ?: return@forEach
+            val tableField: TableField? = field.getAnnotation(TableField::class.java)
+            if (tableField?.exist == false) return@forEach
+            val column = TypeAdapterFactory.register(this, it) ?: return@forEach
+            fieldNameColumnMap[it.name] = column
+        }
+    }
+
+    override fun doCreateEntity(row: QueryRowSet, withReferences: Boolean): T {
+        val instance = InstantAllocator[entityClass!!.java, unsafe]
+        columns.forEach {
+            val field = fieldMap[it.name] ?: return@forEach
+            @Suppress("UNCHECKED_CAST")
+            row[it]?.inject(instance, field as KProperty1<Any, Any?>)
+        }
+        return instance
+    }
+
+    /**
+     * get column by property.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public operator fun <R : Any> get(property: KProperty1<out T, R?>): Column<R> =
+        fieldNameColumnMap[property.name] as Column<R>
+
+    /**
+     * get column by property.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public operator fun <R : Any> get(property: KProperty<R?>): Column<R> =
+        fieldNameColumnMap[property.name] as Column<R>
+
+    /**
+     * create table field.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public fun <V : Any> field(): FieldDelegation<T, V> = fieldProxyInstance as FieldDelegation<T, V>
+
+    /**
+     * create table field proxy by property.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public fun <V : Any> field(
+        property: KProperty0<*>,
+    ): Column<V> = fieldNameColumnMap[property.name] as Column<V>
+
+    /**
+     * clone AutoTable instance.
+     */
+    public fun clone(
+        entityClass: KClass<T> = super.entityClass!!,
+        tableName: String = super.tableName,
+        alias: String? = super.alias,
+        catalog: String? = super.catalog,
+        schema: String? = super.schema,
+        unsafe: Boolean = this.unsafe,
+    ): AutoTable<T> {
+        return AutoTable(
+            entityClass,
+            tableName,
+            alias,
+            catalog,
+            schema,
+            unsafe,
+            fieldMap,
+            fieldNameColumnMap
+        )
+    }
+
+    public companion object {
+        /**
+         * get AutoTable instance.
+         */
+        public operator fun <T : Any> get(clazz: KClass<T>): AutoTable<T> =
+            get(clazz.java)
+
+        /**
+         * get AutoTable instance.
+         */
+        public operator fun <T : Any> get(clazz: Class<T>): AutoTable<T> {
+            var autoTable = autoTableMap[clazz]
+            if (autoTable == null) {
+                synchronized(autoTableMap) {
+                    autoTable = autoTableMap[clazz]
+                    if (autoTable == null) {
+                        autoTable = AutoTable(clazz.kotlin)
+                        @Suppress("UNCHECKED_CAST")
+                        autoTableMap[clazz] = autoTable as AutoTable<T>
+                    }
+                }
+            }
+            @Suppress("UNCHECKED_CAST")
+            return autoTable as AutoTable<T>
+        }
+
+        /**
+         * get AutoTable instance.
+         */
+        public inline operator fun <reified T : Any> invoke(): AutoTable<T> = get(T::class.java)
+
+        /**
+         * table field delegation provider.
+         */
+        public class FieldDelegation<T : Any, V : Any> {
+            /**
+             * kotlin delegation operator to get value.
+             */
+            @Suppress("UNCHECKED_CAST")
+            public operator fun getValue(
+                autoTable: AutoTable<T>,
+                property: KProperty<*>,
+            ): Column<V> = autoTable.fieldNameColumnMap[property.name] as Column<V>
+        }
+
+        private val fieldProxyInstance = FieldDelegation<Any, Any>()
+        private val autoTableMap = ConcurrentHashMap<Class<*>, AutoTable<*>>()
+    }
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/InstantAllocator.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/InstantAllocator.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
+
+internal object InstantAllocator {
+    enum class AllocateFunction { INSTANCE, UNSAFE, KOBJECT, NONE }
+
+    private val allocateFunctionMap = ConcurrentHashMap<Class<*>, AllocateFunction>()
+
+    operator fun <T> invoke(
+        clazz: Class<out T>,
+        unsafe: Boolean = true,
+    ): T = get(clazz, unsafe)
+
+    inline operator fun <reified T : Any> invoke(
+        unsafe: Boolean = true,
+    ): T = get(T::class.java, unsafe)
+
+    operator fun <T : Any> get(
+        clazz: KClass<out T>,
+        unsafe: Boolean = true,
+    ): T = get(clazz.java, unsafe)
+
+    operator fun <T> get(clazz: Class<out T>, unsafe: Boolean = true): T {
+        return when (allocateFunctionMap[clazz]) {
+            null -> try {
+                val newInstance = clazz.newInstance()
+                allocateFunctionMap[clazz] = AllocateFunction.INSTANCE
+                newInstance
+            } catch (e: Exception) {
+                val kClass = clazz.kotlin
+                val objectInstance = kClass.objectInstance
+                when {
+                    objectInstance != null -> {
+                        allocateFunctionMap[clazz] = AllocateFunction.KOBJECT
+                        objectInstance
+                    }
+                    unsafe -> try {
+                        allocateFunctionMap[clazz] = AllocateFunction.UNSAFE
+                        @Suppress("UNCHECKED_CAST")
+                        Unsafe.theUnsafe.allocateInstance(clazz) as T
+                    } catch (e: Exception) {
+                        allocateFunctionMap[clazz] = AllocateFunction.NONE
+                        throwNoSuchMethodException(clazz)
+                    }
+                    else -> throwNoSuchMethodException(clazz, e)
+                }
+            }
+            AllocateFunction.INSTANCE -> clazz.newInstance()
+            AllocateFunction.UNSAFE -> if (unsafe) {
+                @Suppress("UNCHECKED_CAST")
+                Unsafe.theUnsafe.allocateInstance(clazz) as T
+            } else {
+                throwNoSuchMethodException(clazz)
+            }
+            AllocateFunction.KOBJECT -> clazz.kotlin.objectInstance!!
+            AllocateFunction.NONE -> throwNoSuchMethodException(clazz)
+        }
+    }
+
+    private fun throwNoSuchMethodException(clazz: Class<*>, e: Exception? = null): Nothing {
+        throw NoSuchMethodException("${clazz.name}:<init>()").initCause(e)
+    }
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/SqlExtension.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/SqlExtension.kt
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("unused")
+
+package org.ktorm.autotable
+
+import org.ktorm.autotable.annotations.TableField
+import org.ktorm.autotable.annotations.TableName
+import org.ktorm.dsl.Query
+import org.ktorm.dsl.QueryRowSet
+import org.ktorm.dsl.map
+import org.ktorm.logging.Logger
+import org.ktorm.logging.detectLoggerImplementation
+import org.ktorm.schema.*
+import java.math.BigDecimal
+import java.sql.Date
+import java.sql.Time
+import java.sql.Timestamp
+import java.time.*
+import java.util.*
+import kotlin.reflect.*
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaField
+
+private val logger: Logger = detectLoggerImplementation()
+
+internal val String.sqlName: String
+    get() {
+        val sb = StringBuilder()
+        val iterator = iterator()
+        sb.append(iterator.nextChar().toLowerCase())
+        iterator.forEach {
+            if (it.isUpperCase()) {
+                sb.append('_')
+                sb.append(it.toLowerCase())
+            } else {
+                sb.append(it)
+            }
+        }
+        return sb.toString()
+    }
+internal val KClass<*>.tableName: String
+    get() = findAnnotation<TableName>()?.name ?: simpleName!!.sqlName
+internal val Class<*>.tableName: String
+    get() = getAnnotation(TableName::class.java)?.name ?: simpleName.sqlName
+internal val KProperty<*>.tableFieldName: String?
+    get() = javaField?.getAnnotation(TableField::class.java)?.name
+internal val KProperty<*>.simpTableField: String
+    get() = tableFieldName ?: name.sqlName
+
+/**
+ * get AutoTable instance of property.
+ */
+public val KProperty<*>.table: AutoTable<Any>
+    @Suppress("UNCHECKED_CAST")
+    get() = AutoTable[javaField!!.declaringClass] as AutoTable<Any>
+
+/**
+ * get Column instance of property.
+ */
+public val <T : Any> KProperty<T?>.sql: Column<T>
+    get() = table[this]
+
+/**
+ * get AutoTable instance of property.
+ */
+public inline val <reified T : Any> KProperty1<out T, *>.table: AutoTable<T>
+    get() = AutoTable[T::class.java]
+
+/**
+ * get one data instance of query.
+ */
+public fun <T> Query.getOne(
+    transform: (rowSet: QueryRowSet) -> T,
+): T? = if (rowSet.next()) {
+    transform(rowSet)
+} else {
+    null
+}
+
+/**
+ * get one data instance of query.
+ */
+public inline fun <reified T : Any> Query.getOne(): T? = if (rowSet.next()) {
+    AutoTable[T::class].createEntity(rowSet)
+} else {
+    null
+}
+
+/**
+ * convert data contains in Query to List.
+ */
+public inline fun <reified T : Any> Query.toList(
+    table: AutoTable<T>,
+): List<T> = map {
+    table.createEntity(it)
+}
+
+/**
+ * Define a column typed of [BooleanSqlType].
+ */
+public fun <E : Any> BaseTable<E>.boolean(
+    field: KProperty1<E, Boolean?>,
+): Column<Boolean> = boolean(field.simpTableField)
+
+/**
+ * Define a column typed of [IntSqlType].
+ */
+public fun <E : Any> BaseTable<E>.int(
+    field: KProperty1<E, Int?>,
+): Column<Int> = int(field.simpTableField)
+
+/**
+ * Define a column typed of [LongSqlType].
+ */
+public fun <E : Any> BaseTable<E>.long(
+    field: KProperty1<E, Long?>,
+): Column<Long> = long(field.simpTableField)
+
+/**
+ * Define a column typed of [FloatSqlType].
+ */
+public fun <E : Any> BaseTable<E>.float(
+    field: KProperty1<E, Float?>,
+): Column<Float> = float(field.simpTableField)
+
+/**
+ * Define a column typed of [DoubleSqlType].
+ */
+public fun <E : Any> BaseTable<E>.double(
+    field: KProperty1<E, Double?>,
+): Column<Double> = double(field.simpTableField)
+
+/**
+ * Define a column typed of [DecimalSqlType].
+ */
+public fun <E : Any> BaseTable<E>.decimal(
+    field: KProperty1<E, BigDecimal?>,
+): Column<BigDecimal> = decimal(field.simpTableField)
+
+/**
+ * Define a column typed of [VarcharSqlType].
+ */
+public fun <E : Any> BaseTable<E>.varchar(
+    field: KProperty1<E, String?>,
+): Column<String> = varchar(field.simpTableField)
+
+/**
+ * Define a column typed of [TextSqlType].
+ */
+public fun <E : Any> BaseTable<E>.text(
+    field: KProperty1<E, String?>,
+): Column<String> = text(field.simpTableField)
+
+/**
+ * Define a column typed of [BlobSqlType].
+ */
+public fun <E : Any> BaseTable<E>.blob(
+    field: KProperty1<E, ByteArray?>,
+): Column<ByteArray> = blob(field.simpTableField)
+
+/**
+ * Define a column typed of [BytesSqlType].
+ */
+public fun <E : Any> BaseTable<E>.bytes(
+    field: KProperty1<E, ByteArray?>,
+): Column<ByteArray> = bytes(field.simpTableField)
+
+/**
+ * Define a column typed of [TimestampSqlType].
+ */
+public fun <E : Any> BaseTable<E>.jdbcTimestamp(
+    field: KProperty1<E, Timestamp?>,
+): Column<Timestamp> = jdbcTimestamp(field.simpTableField)
+
+/**
+ * Define a column typed of [DateSqlType].
+ */
+public fun <E : Any> BaseTable<E>.jdbcDate(
+    field: KProperty1<E, Date?>,
+): Column<Date> = jdbcDate(field.simpTableField)
+
+/**
+ * Define a column typed of [TimeSqlType].
+ */
+public fun <E : Any> BaseTable<E>.jdbcTime(
+    field: KProperty1<E, Time?>,
+): Column<Time> = jdbcTime(field.simpTableField)
+
+/**
+ * Define a column typed of [InstantSqlType].
+ */
+public fun <E : Any> BaseTable<E>.timestamp(
+    field: KProperty1<E, Instant?>,
+): Column<Instant> = timestamp(field.simpTableField)
+
+/**
+ * Define a column typed of [LocalDateTimeSqlType].
+ */
+public fun <E : Any> BaseTable<E>.datetime(
+    field: KProperty1<E, LocalDateTime?>,
+): Column<LocalDateTime> = datetime(field.simpTableField)
+
+/**
+ * Define a column typed of [LocalTimeSqlType].
+ */
+public fun <E : Any> BaseTable<E>.date(
+    field: KProperty1<E, LocalDate?>,
+): Column<LocalDate> = date(field.simpTableField)
+
+/**
+ * Define a column typed of [LocalTimeSqlType].
+ */
+public fun <E : Any> BaseTable<E>.time(
+    field: KProperty1<E, LocalTime?>,
+): Column<LocalTime> = time(field.simpTableField)
+
+/**
+ * Define a column typed of [MonthDaySqlType], instances of [MonthDay] are saved as strings in format `MM-dd`.
+ */
+public fun <E : Any> BaseTable<E>.monthDay(
+    field: KProperty1<E, MonthDay?>,
+): Column<MonthDay> = monthDay(field.simpTableField)
+
+/**
+ * Define a column typed of [YearMonthSqlType], instances of [YearMonth] are saved as strings in format `yyyy-MM`.
+ */
+public fun <E : Any> BaseTable<E>.yearMonth(
+    field: KProperty1<E, YearMonth?>,
+): Column<YearMonth> = yearMonth(field.simpTableField)
+
+/**
+ * Define a column typed of [YearSqlType], instances of [Year] are saved as integers.
+ */
+public fun <E : Any> BaseTable<E>.year(
+    field: KProperty1<E, Year?>,
+): Column<Year> = year(field.simpTableField)
+
+/**
+ * Define a column typed of [UuidSqlType].
+ */
+public fun <E : Any> BaseTable<E>.uuid(
+    field: KProperty1<E, UUID?>,
+): Column<UUID> = uuid(field.simpTableField)
+
+/**
+ * Define a column typed of [C].
+ */
+public fun <E : Any, C : Enum<C>> BaseTable<E>.enum(
+    field: KProperty1<E, C?>,
+    type: Class<C>,
+): Column<C> = registerColumn(field.simpTableField, EnumSqlType(type))
+
+/**
+ * inject value to an property of an instance.
+ */
+internal fun <T : Any> Any.inject(target: T, property: KProperty1<T, Any?>) {
+    when (property) {
+        is KMutableProperty1<*, *> -> {
+            @Suppress("UNCHECKED_CAST")
+            property as KMutableProperty1<T, Any?>
+            property.isAccessible = true
+            try {
+                @OptIn(ExperimentalStdlibApi::class)
+                property.set(
+                    target,
+                    cast(
+                        this,
+                        property.returnType.javaType as Class<*>
+                    ) ?: return
+                )
+                // } catch (e: ClassCastException) {
+            } catch (e: Exception) {
+                logger.trace("inject ${property.name} failed", e)
+            }
+        }
+        else -> {
+            val field = property.javaField ?: return
+            field.isAccessible = true
+            try {
+                field.set(target, cast(this, field.type) ?: return)
+                // } catch (e: ClassCastException) {
+            } catch (e: Exception) {
+                logger.trace("inject ${property.name} failed", e)
+            }
+        }
+    }
+}
+
+internal fun cast(
+    source: Any,
+    target: Class<*>,
+): Any? = when {
+    target.isInstance(source) -> source
+    else -> when (target) {
+        Byte::class.java -> if (source is Number) source.toByte() else source.toString().toByteOrNull()
+        Char::class.java -> if (source is Number) source.toChar() else source.toString().toIntOrNull()?.toChar()
+        Short::class.java -> if (source is Number) source.toShort() else source.toString().toShortOrNull()
+        Int::class.java -> if (source is Number) source.toInt() else source.toString().toIntOrNull()
+        Long::class.java -> if (source is Number) source.toLong() else source.toString().toLongOrNull()
+        Float::class.java -> if (source is Number) source.toFloat() else source.toString().toFloatOrNull()
+        Double::class.java -> if (source is Number) source.toDouble() else source.toString().toDoubleOrNull()
+        Boolean::class.java -> if (source is Number) source != 0 else source.toString().toBoolean()
+        java.lang.Byte::class.java -> if (source is Number) source.toByte() else source.toString().toByteOrNull()
+        java.lang.Character::class.java -> if (source is Number) {
+            source.toChar()
+        } else {
+            source.toString().toIntOrNull()?.toChar()
+        }
+        java.lang.Short::class.java -> if (source is Number) source.toShort() else source.toString().toShortOrNull()
+        java.lang.Integer::class.java -> if (source is Number) source.toInt() else source.toString().toIntOrNull()
+        java.lang.Long::class.java -> if (source is Number) source.toLong() else source.toString().toLongOrNull()
+        java.lang.Float::class.java -> if (source is Number) source.toFloat() else source.toString().toFloatOrNull()
+        java.lang.Double::class.java -> if (source is Number) source.toDouble() else source.toString().toDoubleOrNull()
+        java.lang.Boolean::class.java -> if (source is Number) source != 0 else source.toString().toBoolean()
+        String::class.java -> source.toString()
+        else -> source
+    }
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/SqlExtension.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/SqlExtension.kt
@@ -58,10 +58,8 @@ internal val KClass<*>.tableName: String
     get() = findAnnotation<TableName>()?.name ?: simpleName!!.sqlName
 internal val Class<*>.tableName: String
     get() = getAnnotation(TableName::class.java)?.name ?: simpleName.sqlName
-internal val KProperty<*>.tableFieldName: String?
-    get() = javaField?.getAnnotation(TableField::class.java)?.name
-internal val KProperty<*>.simpTableField: String
-    get() = tableFieldName ?: name.sqlName
+internal val KProperty<*>.tableFieldName: String
+    get() = javaField?.getAnnotation(TableField::class.java)?.name ?: name.sqlName
 
 /**
  * get AutoTable instance of property.
@@ -73,7 +71,7 @@ public val KProperty<*>.table: AutoTable<Any>
 /**
  * get Column instance of property.
  */
-public val <T : Any> KProperty<T?>.sql: Column<T>
+public val <T : Any> KProperty<T?>.column: Column<T>
     get() = table[this]
 
 /**
@@ -116,147 +114,147 @@ public inline fun <reified T : Any> Query.toList(
  */
 public fun <E : Any> BaseTable<E>.boolean(
     field: KProperty1<E, Boolean?>,
-): Column<Boolean> = boolean(field.simpTableField)
+): Column<Boolean> = boolean(field.tableFieldName)
 
 /**
  * Define a column typed of [IntSqlType].
  */
 public fun <E : Any> BaseTable<E>.int(
     field: KProperty1<E, Int?>,
-): Column<Int> = int(field.simpTableField)
+): Column<Int> = int(field.tableFieldName)
 
 /**
  * Define a column typed of [LongSqlType].
  */
 public fun <E : Any> BaseTable<E>.long(
     field: KProperty1<E, Long?>,
-): Column<Long> = long(field.simpTableField)
+): Column<Long> = long(field.tableFieldName)
 
 /**
  * Define a column typed of [FloatSqlType].
  */
 public fun <E : Any> BaseTable<E>.float(
     field: KProperty1<E, Float?>,
-): Column<Float> = float(field.simpTableField)
+): Column<Float> = float(field.tableFieldName)
 
 /**
  * Define a column typed of [DoubleSqlType].
  */
 public fun <E : Any> BaseTable<E>.double(
     field: KProperty1<E, Double?>,
-): Column<Double> = double(field.simpTableField)
+): Column<Double> = double(field.tableFieldName)
 
 /**
  * Define a column typed of [DecimalSqlType].
  */
 public fun <E : Any> BaseTable<E>.decimal(
     field: KProperty1<E, BigDecimal?>,
-): Column<BigDecimal> = decimal(field.simpTableField)
+): Column<BigDecimal> = decimal(field.tableFieldName)
 
 /**
  * Define a column typed of [VarcharSqlType].
  */
 public fun <E : Any> BaseTable<E>.varchar(
     field: KProperty1<E, String?>,
-): Column<String> = varchar(field.simpTableField)
+): Column<String> = varchar(field.tableFieldName)
 
 /**
  * Define a column typed of [TextSqlType].
  */
 public fun <E : Any> BaseTable<E>.text(
     field: KProperty1<E, String?>,
-): Column<String> = text(field.simpTableField)
+): Column<String> = text(field.tableFieldName)
 
 /**
  * Define a column typed of [BlobSqlType].
  */
 public fun <E : Any> BaseTable<E>.blob(
     field: KProperty1<E, ByteArray?>,
-): Column<ByteArray> = blob(field.simpTableField)
+): Column<ByteArray> = blob(field.tableFieldName)
 
 /**
  * Define a column typed of [BytesSqlType].
  */
 public fun <E : Any> BaseTable<E>.bytes(
     field: KProperty1<E, ByteArray?>,
-): Column<ByteArray> = bytes(field.simpTableField)
+): Column<ByteArray> = bytes(field.tableFieldName)
 
 /**
  * Define a column typed of [TimestampSqlType].
  */
 public fun <E : Any> BaseTable<E>.jdbcTimestamp(
     field: KProperty1<E, Timestamp?>,
-): Column<Timestamp> = jdbcTimestamp(field.simpTableField)
+): Column<Timestamp> = jdbcTimestamp(field.tableFieldName)
 
 /**
  * Define a column typed of [DateSqlType].
  */
 public fun <E : Any> BaseTable<E>.jdbcDate(
     field: KProperty1<E, Date?>,
-): Column<Date> = jdbcDate(field.simpTableField)
+): Column<Date> = jdbcDate(field.tableFieldName)
 
 /**
  * Define a column typed of [TimeSqlType].
  */
 public fun <E : Any> BaseTable<E>.jdbcTime(
     field: KProperty1<E, Time?>,
-): Column<Time> = jdbcTime(field.simpTableField)
+): Column<Time> = jdbcTime(field.tableFieldName)
 
 /**
  * Define a column typed of [InstantSqlType].
  */
 public fun <E : Any> BaseTable<E>.timestamp(
     field: KProperty1<E, Instant?>,
-): Column<Instant> = timestamp(field.simpTableField)
+): Column<Instant> = timestamp(field.tableFieldName)
 
 /**
  * Define a column typed of [LocalDateTimeSqlType].
  */
 public fun <E : Any> BaseTable<E>.datetime(
     field: KProperty1<E, LocalDateTime?>,
-): Column<LocalDateTime> = datetime(field.simpTableField)
+): Column<LocalDateTime> = datetime(field.tableFieldName)
 
 /**
  * Define a column typed of [LocalTimeSqlType].
  */
 public fun <E : Any> BaseTable<E>.date(
     field: KProperty1<E, LocalDate?>,
-): Column<LocalDate> = date(field.simpTableField)
+): Column<LocalDate> = date(field.tableFieldName)
 
 /**
  * Define a column typed of [LocalTimeSqlType].
  */
 public fun <E : Any> BaseTable<E>.time(
     field: KProperty1<E, LocalTime?>,
-): Column<LocalTime> = time(field.simpTableField)
+): Column<LocalTime> = time(field.tableFieldName)
 
 /**
  * Define a column typed of [MonthDaySqlType], instances of [MonthDay] are saved as strings in format `MM-dd`.
  */
 public fun <E : Any> BaseTable<E>.monthDay(
     field: KProperty1<E, MonthDay?>,
-): Column<MonthDay> = monthDay(field.simpTableField)
+): Column<MonthDay> = monthDay(field.tableFieldName)
 
 /**
  * Define a column typed of [YearMonthSqlType], instances of [YearMonth] are saved as strings in format `yyyy-MM`.
  */
 public fun <E : Any> BaseTable<E>.yearMonth(
     field: KProperty1<E, YearMonth?>,
-): Column<YearMonth> = yearMonth(field.simpTableField)
+): Column<YearMonth> = yearMonth(field.tableFieldName)
 
 /**
  * Define a column typed of [YearSqlType], instances of [Year] are saved as integers.
  */
 public fun <E : Any> BaseTable<E>.year(
     field: KProperty1<E, Year?>,
-): Column<Year> = year(field.simpTableField)
+): Column<Year> = year(field.tableFieldName)
 
 /**
  * Define a column typed of [UuidSqlType].
  */
 public fun <E : Any> BaseTable<E>.uuid(
     field: KProperty1<E, UUID?>,
-): Column<UUID> = uuid(field.simpTableField)
+): Column<UUID> = uuid(field.tableFieldName)
 
 /**
  * Define a column typed of [C].
@@ -264,7 +262,7 @@ public fun <E : Any> BaseTable<E>.uuid(
 public fun <E : Any, C : Enum<C>> BaseTable<E>.enum(
     field: KProperty1<E, C?>,
     type: Class<C>,
-): Column<C> = registerColumn(field.simpTableField, EnumSqlType(type))
+): Column<C> = registerColumn(field.tableFieldName, EnumSqlType(type))
 
 /**
  * inject value to an property of an instance.

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/TypeAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/TypeAdapter.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable
+
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import kotlin.reflect.KProperty1
+
+/**
+ * 将属性转化为表列的适配器.
+ */
+public interface TypeAdapter<T : Any> {
+    /**
+     * 该适配器的优先级，优先级越高则越优先匹配.
+     * 同等优先级先注册者先匹配.
+     */
+    public val priority: Int get() = 0
+
+    /**
+     * 注册列.
+     * 如果失败则返回null.
+     */
+    public fun register(
+        table: BaseTable<Any>,
+        field: KProperty1<Any, T>,
+    ): Column<T>?
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/TypeAdapterFactory.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/TypeAdapterFactory.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable
+
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import org.reflections.Reflections
+import java.util.concurrent.ConcurrentSkipListMap
+import java.util.concurrent.CopyOnWriteArraySet
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.isSubclassOf
+
+/**
+ * An factory to register TypeAdapter and Column.
+ */
+public object TypeAdapterFactory {
+    private val adapterMap = ConcurrentSkipListMap<Int, MutableSet<TypeAdapter<*>>>()
+
+    init {
+        scanPackage(TypeAdapterFactory::class.java.`package`.name + ".typeadapter")
+    }
+
+    private fun getAdapterQueue(priority: Int): MutableCollection<TypeAdapter<*>> {
+        var set = adapterMap[-priority]
+        if (set == null) {
+            synchronized(this) {
+                adapterMap[-priority] = CopyOnWriteArraySet()
+                set = adapterMap[-priority]!!
+            }
+        }
+        return set!!
+    }
+
+    /**
+     * 扫描包并注册适配器.
+     */
+    public fun scanPackage(pkg: String) {
+        Reflections(pkg).getSubTypesOf(TypeAdapter::class.java).forEach { jClazz ->
+            try {
+                val clazz = jClazz.kotlin
+                if (clazz.isSubclassOf(TypeAdapter::class)) {
+                    @Suppress("UNCHECKED_CAST")
+                    val adapter = InstantAllocator[clazz] as TypeAdapter<*>
+                    registerAdapter(adapter)
+                }
+            } catch (e: Throwable) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    /**
+     * 注册适配器实例.
+     */
+    public fun registerAdapter(adapter: TypeAdapter<*>) {
+        getAdapterQueue(adapter.priority).add(adapter)
+    }
+
+    public fun register(
+        table: BaseTable<*>,
+        field: KProperty1<*, *>,
+    ): Column<*>? {
+        adapterMap.forEach { (_, queue) ->
+            queue.forEach {
+                @Suppress("UNCHECKED_CAST")
+                val column = it.register(table as BaseTable<Any>, field as KProperty1<Any, Nothing>)
+                if (column != null) {
+                    return column
+                }
+            }
+        }
+        return null
+    }
+
+    override fun toString(): String = adapterMap.toString()
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/Unsafe.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/Unsafe.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable
+
+internal object Unsafe {
+    val theUnsafe: sun.misc.Unsafe
+
+    init {
+        val theUnsafe = Unsafe::class.java.getDeclaredField("theUnsafe")
+        theUnsafe.isAccessible = true
+        this.theUnsafe = theUnsafe.get(null) as sun.misc.Unsafe
+    }
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/annotations/TableField.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/annotations/TableField.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.annotations
+
+/**
+ * declare table field.
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+public annotation class TableField(
+    /**
+     * declare field name.
+     */
+    val name: String = "",
+    /**
+     * declare field exist.
+     */
+    val exist: Boolean = true,
+)

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/annotations/TableName.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/annotations/TableName.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.annotations
+
+/**
+ * declare table name.
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
+public annotation class TableName(
+    /**
+     * declare table name.
+     */
+    val name: String = "",
+)

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/BigDecimalAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/BigDecimalAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.decimal
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.math.BigDecimal
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register BigDecimal Column.
+ */
+public object BigDecimalAdapter : TypeAdapter<BigDecimal> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, BigDecimal>): Column<BigDecimal>? {
+        return if (field.returnType.jvmErasure == BigDecimal::class) {
+            table.decimal(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "BigDecimalAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/BooleanAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/BooleanAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.boolean
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Boolean Column.
+ */
+@Suppress("unused")
+public object BooleanAdapter : TypeAdapter<Boolean> {
+    public override fun register(table: BaseTable<Any>, field: KProperty1<Any, Boolean>): Column<Boolean>? {
+        return if (field.returnType.jvmErasure == Boolean::class) {
+            table.boolean(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "BooleanAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/BytesAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/BytesAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.bytes
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Bytes Column.
+ */
+@Suppress("unused")
+public object BytesAdapter : TypeAdapter<ByteArray> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, ByteArray>): Column<ByteArray>? {
+        return if (field.returnType.jvmErasure == ByteArray::class) {
+            table.bytes(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "BytesAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/DateAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/DateAdapter.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.jdbcDate
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.sql.Date
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Date Column.
+ */
+@Suppress("unused")
+public object DateAdapter : TypeAdapter<Date> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Date>): Column<Date>? {
+        return if (field.returnType.jvmErasure == Date::class) {
+            table.jdbcDate(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "DateAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/DoubleAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/DoubleAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.double
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Double Column.
+ */
+@Suppress("unused")
+public object DoubleAdapter : TypeAdapter<Double> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Double>): Column<Double>? {
+        return if (field.returnType.jvmErasure == Double::class) {
+            table.double(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "DoubleAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/EnumAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/EnumAdapter.kt
@@ -17,7 +17,7 @@
 package org.ktorm.autotable.typeadapter
 
 import org.ktorm.autotable.TypeAdapter
-import org.ktorm.autotable.simpTableField
+import org.ktorm.autotable.tableFieldName
 import org.ktorm.schema.BaseTable
 import org.ktorm.schema.Column
 import org.ktorm.schema.EnumSqlType
@@ -38,7 +38,7 @@ public object EnumAdapter : TypeAdapter<EnumAdapter.EnumType> {
         val kClass = field.returnType.jvmErasure
         return if (kClass.isSubclassOf(Enum::class)) {
             @Suppress("UNCHECKED_CAST")
-            table.registerColumn(field.simpTableField, EnumSqlType(kClass.java as Class<EnumType>))
+            table.registerColumn(field.tableFieldName, EnumSqlType(kClass.java as Class<EnumType>))
         } else {
             null
         }

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/EnumAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/EnumAdapter.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.simpTableField
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import org.ktorm.schema.EnumSqlType
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Enum Column.
+ */
+public object EnumAdapter : TypeAdapter<EnumAdapter.EnumType> {
+    /**
+     * Placeholder of enum.
+     */
+    public enum class EnumType
+
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, EnumType>): Column<EnumType>? {
+        val kClass = field.returnType.jvmErasure
+        return if (kClass.isSubclassOf(Enum::class)) {
+            @Suppress("UNCHECKED_CAST")
+            table.registerColumn(field.simpTableField, EnumSqlType(kClass.java as Class<EnumType>))
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "EnumAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/FloatAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/FloatAdapter.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.float
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Float Column.
+ */
+public object FloatAdapter : TypeAdapter<Float> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Float>): Column<Float>? {
+        return if (field.returnType.jvmErasure == Float::class) {
+            table.float(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "FloatAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/InstantAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/InstantAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.timestamp
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.time.Instant
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Instant Column.
+ */
+public object InstantAdapter : TypeAdapter<Instant> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Instant>): Column<Instant>? {
+        return if (field.returnType.jvmErasure == Instant::class) {
+            table.timestamp(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "InstantAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/IntAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/IntAdapter.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.int
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Int Column.
+ */
+public object IntAdapter : TypeAdapter<Int> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Int>): Column<Int>? {
+        return if (field.returnType.jvmErasure == Int::class) {
+            table.int(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "IntAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/LocalDateAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/LocalDateAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.date
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.time.LocalDate
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register LocalDate Column.
+ */
+public object LocalDateAdapter : TypeAdapter<LocalDate> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, LocalDate>): Column<LocalDate>? {
+        return if (field.returnType.jvmErasure == LocalDate::class) {
+            table.date(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "LocalDateAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/LocalDateTimeAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/LocalDateTimeAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.datetime
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.time.LocalDateTime
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register LocalDateTime Column.
+ */
+public object LocalDateTimeAdapter : TypeAdapter<LocalDateTime> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, LocalDateTime>): Column<LocalDateTime>? {
+        return if (field.returnType.jvmErasure == LocalDateTime::class) {
+            table.datetime(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "LocalDateTimeAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/LocalTimeAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/LocalTimeAdapter.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.time
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.time.LocalTime
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register LocalTime Column.
+ */
+@Suppress("unused")
+public object LocalTimeAdapter : TypeAdapter<LocalTime> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, LocalTime>): Column<LocalTime>? {
+        return if (field.returnType.jvmErasure == LocalTime::class) {
+            table.time(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "LocalTimeAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/LongAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/LongAdapter.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.long
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Long Column.
+ */
+public object LongAdapter : TypeAdapter<Long> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Long>): Column<Long>? {
+        return if (field.returnType.jvmErasure == Long::class) {
+            table.long(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "LongAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/MonthDayAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/MonthDayAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.monthDay
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.time.MonthDay
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register MonthDay Column.
+ */
+public object MonthDayAdapter : TypeAdapter<MonthDay> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, MonthDay>): Column<MonthDay>? {
+        return if (field.returnType.jvmErasure == MonthDay::class) {
+            table.monthDay(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "MonthDayAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/StringAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/StringAdapter.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.varchar
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register String Column.
+ */
+public object StringAdapter : TypeAdapter<String> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, String>): Column<String>? {
+        return if (field.returnType.jvmErasure == String::class) {
+            table.varchar(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "StringAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/TimeAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/TimeAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.jdbcTime
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.sql.Time
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Time Column.
+ */
+public object TimeAdapter : TypeAdapter<Time> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Time>): Column<Time>? {
+        return if (field.returnType.jvmErasure == Time::class) {
+            table.jdbcTime(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "TimeAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/TimestampAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/TimestampAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.jdbcTimestamp
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.sql.Timestamp
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Timestamp Column.
+ */
+public object TimestampAdapter : TypeAdapter<Timestamp> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Timestamp>): Column<Timestamp>? {
+        return if (field.returnType.jvmErasure == Timestamp::class) {
+            table.jdbcTimestamp(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "TimestampAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/UUIDAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/UUIDAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.uuid
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.util.*
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register UUID Column.
+ */
+public object UUIDAdapter : TypeAdapter<UUID> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, UUID>): Column<UUID>? {
+        return if (field.returnType.jvmErasure == UUID::class) {
+            table.uuid(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "UUIDAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/YearAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/YearAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.year
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.time.Year
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register Year Column.
+ */
+public object YearAdapter : TypeAdapter<Year> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, Year>): Column<Year>? {
+        return if (field.returnType.jvmErasure == Year::class) {
+            table.year(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "YearAdapter"
+}

--- a/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/YearMonthAdapter.kt
+++ b/ktorm-autotable/src/main/kotlin/org/ktorm/autotable/typeadapter/YearMonthAdapter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.autotable.typeadapter
+
+import org.ktorm.autotable.TypeAdapter
+import org.ktorm.autotable.yearMonth
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.time.YearMonth
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * TypeAdapter to register YearMonth Column.
+ */
+public object YearMonthAdapter : TypeAdapter<YearMonth> {
+    override fun register(table: BaseTable<Any>, field: KProperty1<Any, YearMonth>): Column<YearMonth>? {
+        return if (field.returnType.jvmErasure == YearMonth::class) {
+            table.yearMonth(field)
+        } else {
+            null
+        }
+    }
+
+    override fun toString(): String = "YearMonthAdapter"
+}

--- a/ktorm-autotable/src/test/kotlin/org/ktorm/autotable/TypeAdapterFactoryTest.kt
+++ b/ktorm-autotable/src/test/kotlin/org/ktorm/autotable/TypeAdapterFactoryTest.kt
@@ -1,0 +1,166 @@
+package org.ktorm.autotable
+
+import org.junit.Test
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+import java.math.BigDecimal
+import java.sql.Date
+import java.sql.Time
+import java.sql.Timestamp
+import java.time.*
+import java.util.*
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.jvm.jvmName
+
+class TypeAdapterFactoryTest {
+    class TestType(
+        val testField: TestType? = null,
+        val testBigDecimal: BigDecimal? = null,
+        val testBoolean: Boolean? = null,
+        val testBytes: ByteArray? = null,
+        val testDate: Date? = null,
+        val testDouble: Double? = null,
+        val testEnum: Enum<*>? = null,
+        val testFloat: Float? = null,
+        val testInstant: Instant? = null,
+        val testInt: Int? = null,
+        val testLocalDate: LocalDate? = null,
+        val testLocalDateTime: LocalDateTime? = null,
+        val testLocalTime: LocalTime? = null,
+        val testLong: Long? = null,
+        val testMonth: Month? = null,
+        val testString: String? = null,
+        val testTime: Time? = null,
+        val testTimestamp: Timestamp? = null,
+        val testUUID: UUID? = null,
+        val testYear: Year? = null,
+        val testYearMonth: YearMonth? = null,
+    )
+
+    object TestTypeAdapter : TypeAdapter<String> {
+        override fun register(table: BaseTable<Any>, field: KProperty1<Any, String>): Column<String>? {
+            return if (field.returnType.jvmErasure == TestType::class) {
+                table.text(field)
+            } else {
+                null
+            }
+        }
+    }
+
+    @Test
+    fun testScanPackage() {
+        TypeAdapterFactory.scanPackage(TypeAdapterFactoryTest::class.jvmName)
+        AutoTable<TestType>().rebuild()
+        // get testField column with registered TestTypeAdapter
+        TestType::testField.column
+    }
+
+    @Test
+    fun testRegisterAdapter() {
+        TypeAdapterFactory.registerAdapter(TestTypeAdapter)
+        AutoTable<TestType>().rebuild()
+        // get testField column with registered TestTypeAdapter
+        TestType::testField.column
+    }
+
+    @Test
+    fun testBigDecimal() {
+        TestType::testBigDecimal.column
+    }
+
+    @Test
+    fun testBoolean() {
+        TestType::testBoolean.column
+    }
+
+    @Test
+    fun testBytes() {
+        TestType::testBytes.column
+    }
+
+    @Test
+    fun testDate() {
+        TestType::testDate.column
+    }
+
+    @Test
+    fun testDouble() {
+        TestType::testDouble.column
+    }
+
+    @Test
+    fun testEnum() {
+        TestType::testEnum.column
+    }
+
+    @Test
+    fun testFloat() {
+        TestType::testFloat.column
+    }
+
+    @Test
+    fun testInstant() {
+        TestType::testInstant.column
+    }
+
+    @Test
+    fun testInt() {
+        TestType::testInt.column
+    }
+
+    @Test
+    fun testLocalDate() {
+        TestType::testLocalDate.column
+    }
+
+    @Test
+    fun testLocalDateTime() {
+        TestType::testLocalDateTime.column
+    }
+
+    @Test
+    fun testLocalTime() {
+        TestType::testLocalTime.column
+    }
+
+    @Test
+    fun testLong() {
+        TestType::testLong.column
+    }
+
+    @Test
+    fun testMonth() {
+        TestType::testMonth.column
+    }
+
+    @Test
+    fun testString() {
+        TestType::testString.column
+    }
+
+    @Test
+    fun testTime() {
+        TestType::testTime.column
+    }
+
+    @Test
+    fun testTimestamp() {
+        TestType::testTimestamp.column
+    }
+
+    @Test
+    fun testUUID() {
+        TestType::testUUID.column
+    }
+
+    @Test
+    fun testYear() {
+        TestType::testYear.column
+    }
+
+    @Test
+    fun testYearMonth() {
+        TestType::testYearMonth.column
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@
 include "ktorm-core"
 include "ktorm-global"
 include "ktorm-jackson"
+include "ktorm-autotable"
 include "ktorm-support-mysql"
 include "ktorm-support-oracle"
 include "ktorm-support-postgresql"


### PR DESCRIPTION
通过新加的 AutoTable 类，可以自动化的将数据类中的属性映射为 BaseTable 中的列。支持大部分 sql 类型，并且支持自定义类型。