### PR TITLE
Create tables / Migrations (issue #64)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,11 @@ subprojects { project ->
                             name = "Eric Fenderbosch"
                             email = "eric@fender.net"
                         }
+                        developer {
+                            id = "unknownjoe796"
+                            name = "Joseph Ivie"
+                            email = "joseph@lightningkite.com"
+                        }
                     }
                 }
             }

--- a/ktorm-core/src/main/kotlin/org/ktorm/dsl/SchemaDml.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/dsl/SchemaDml.kt
@@ -1,0 +1,27 @@
+package org.ktorm.dsl
+
+import org.ktorm.expression.ArgumentExpression
+import org.ktorm.expression.ScalarExpression
+import org.ktorm.schema.*
+
+
+public fun <C : Any> Column<C>.unique(): Column<C> {
+    return this.copy(constraints = constraints + UniqueConstraint)
+}
+public fun <C : Any> Column<C>.foreignKey(
+    to: BaseTable<*>,
+    @Suppress("UNCHECKED_CAST") on: Column<C> = to.singlePrimaryKey {
+        "Foreign key cannot be defined this way if there are multiple primary keys on the other"
+    } as Column<C>
+): Column<C> {
+    return this.copy(constraints = constraints + ForeignKeyConstraint(to, on))
+}
+public fun <C : Any> Column<C>.notNull(): Column<C> {
+    return this.copy(constraints = constraints + NotNullConstraint)
+}
+public fun <C : Any> Column<C>.default(value: ScalarExpression<C>): Column<C> {
+    return this.copy(constraints = constraints + DefaultConstraint(value))
+}
+public fun <C : Any> Column<C>.default(value: C): Column<C> {
+    return this.copy(constraints = constraints + DefaultConstraint(ArgumentExpression(value, this.sqlType)))
+}

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlSchemaExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlSchemaExpressions.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.expression
+
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.SqlType
+import kotlin.reflect.KClass
+
+// Indexes
+
+public data class CreateIndexExpression(
+    val name: String,
+    val on: TableReferenceExpression,
+    val columns: List<ColumnExpression<*>>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class DropIndexExpression(
+    val name: String,
+    val on: TableReferenceExpression,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+
+// Views
+
+public data class CreateViewExpression(
+    val name: TableReferenceExpression,
+    val query: SelectExpression,
+    val orReplace: Boolean = false,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class DropViewExpression(
+    val name: TableReferenceExpression,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+// Tables
+
+public data class CreateTableExpression(
+    val name: TableReferenceExpression,
+    val columns: List<ColumnDeclarationExpression<*>>,
+    val constraints: Map<String, TableConstraintExpression> = emptyMap(),
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class DropTableExpression(
+    val table: TableReferenceExpression,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class TruncateTableExpression(
+    val table: TableReferenceExpression,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class AlterTableAddExpression(
+    val table: TableReferenceExpression,
+    val column: ColumnDeclaringExpression<*>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class AlterTableDropColumnExpression(
+    val table: TableReferenceExpression,
+    val column: ColumnExpression<*>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class AlterTableModifyColumnExpression(
+    val table: TableReferenceExpression,
+    val column: ColumnExpression<*>,
+    val newType: SqlType<*>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class AlterTableSetColumnConstraintExpression<T : Any>(
+    val table: TableReferenceExpression,
+    val column: ColumnExpression<T>,
+    val tableConstraint: ColumnConstraintExpression<T>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class AlterTableDropColumnConstraintExpression(
+    val table: TableReferenceExpression,
+    val column: ColumnExpression<*>,
+    val type: KClass<ColumnConstraintExpression<*>>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class AlterTableAddConstraintExpression(
+    val table: TableReferenceExpression,
+    val constraintName: String,
+    val tableConstraint: TableConstraintExpression,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public data class AlterTableDropConstraintExpression(
+    val table: TableReferenceExpression,
+    val constraintName: String,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+// Components
+
+public data class ColumnDeclarationExpression<T : Any>(
+    val name: String,
+    val sqlType: SqlType<T>,
+    val constraints: List<ColumnConstraintExpression<T>> = emptyList(),
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+public abstract class TableConstraintExpression() : SqlExpression()
+public data class ForeignKeyTableConstraintExpression(
+    val otherTable: TableReferenceExpression,
+    val correspondence: Map<ColumnExpression<*>, ColumnExpression<*>>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : TableConstraintExpression()
+
+public data class CheckTableConstraintExpression(
+    val condition: ScalarExpression<Boolean>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : TableConstraintExpression()
+
+public data class UniqueTableConstraintExpression(
+    val across: List<ColumnExpression<*>>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : TableConstraintExpression()
+
+public data class PrimaryKeyTableConstraintExpression(
+    val across: List<ColumnExpression<*>>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : TableConstraintExpression()
+
+public abstract class ColumnConstraintExpression<in T : Any>() : SqlExpression()
+public object PrimaryKeyColumnConstraintExpression : ColumnConstraintExpression<Any>() {
+    override val isLeafNode: Boolean
+        get() = true
+    override val extraProperties: Map<String, Any>
+        get() = mapOf()
+}
+
+public object UniqueColumnConstraintExpression : ColumnConstraintExpression<Any>() {
+    override val isLeafNode: Boolean
+        get() = true
+    override val extraProperties: Map<String, Any>
+        get() = mapOf()
+}
+
+public object NotNullColumnConstraintExpression : ColumnConstraintExpression<Any>() {
+    override val isLeafNode: Boolean
+        get() = true
+    override val extraProperties: Map<String, Any>
+        get() = mapOf()
+}
+
+public data class DefaultColumnConstraintExpression<T : Any>(
+    val value: ScalarExpression<T>
+) : ColumnConstraintExpression<T>() {
+    override val isLeafNode: Boolean
+        get() = true
+    override val extraProperties: Map<String, Any>
+        get() = mapOf()
+}
+
+public data class AutoIncrementColumnConstraintExpression<T : Any>(
+    val startAt: Int = 0,
+    val increaseBy: Int = 1
+) : ColumnConstraintExpression<T>() {
+    override val isLeafNode: Boolean
+        get() = true
+    override val extraProperties: Map<String, Any>
+        get() = mapOf()
+}
+
+public data class TableReferenceExpression(
+    val name: String,
+    val catalog: String? = null,
+    val schema: String? = null,
+    override val isLeafNode: Boolean = true,
+    override val extraProperties: Map<String, Any> = mapOf(),
+): SqlExpression()
+public fun BaseTable<*>.asReferenceExpression(): TableReferenceExpression = TableReferenceExpression(name = tableName, catalog = catalog, schema = schema)

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlSchemaFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlSchemaFormatter.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.expression
+
+import org.ktorm.database.Database
+import org.ktorm.database.DialectFeatureNotSupportedException
+
+/**
+ * Subclass of [SqlExpressionVisitor], visiting SQL expression trees using visitor pattern. After the visit completes,
+ * the executable SQL string will be generated in the [sql] property with its execution parameters in [parameters].
+ *
+ * @property database the current database object used to obtain metadata such as identifier quote string.
+ * @property beautifySql mark if we should output beautiful SQL strings with line-wrapping and indentation.
+ * @property indentSize the indent size.
+ * @property sql return the executable SQL string after the visit completes.
+ * @property parameters return the SQL's execution parameters after the visit completes.
+ */
+@Suppress("VariableNaming")
+public abstract class SqlSchemaFormatter(
+    database: Database,
+    beautifySql: Boolean,
+    indentSize: Int
+) : SqlFormatter(database, beautifySql, indentSize) {
+
+    override fun visit(expr: SqlExpression): SqlExpression {
+        return when(expr){
+            PrimaryKeyColumnConstraintExpression -> visitPrimaryKeyColumnConstraint(PrimaryKeyColumnConstraintExpression)
+            UniqueColumnConstraintExpression -> visitUniqueColumnConstraint(UniqueColumnConstraintExpression)
+            NotNullColumnConstraintExpression -> visitNotNullColumnConstraint(NotNullColumnConstraintExpression)
+            is TableReferenceExpression -> visitTableReference(expr)
+            is CreateTableExpression -> visitCreateTable(expr)
+            is DropTableExpression -> visitDropTable(expr)
+            is TruncateTableExpression -> visitTruncateTable(expr)
+            is AlterTableAddExpression -> visitAlterTableAdd(expr)
+            is AlterTableDropColumnExpression -> visitAlterTableDropColumn(expr)
+            is AlterTableModifyColumnExpression -> visitAlterTableModifyColumn(expr)
+            is AlterTableSetColumnConstraintExpression<*> -> visitAlterTableSetColumnConstraint(expr)
+            is AlterTableDropColumnConstraintExpression -> visitAlterTableDropColumnConstraint(expr)
+            is AlterTableAddConstraintExpression -> visitAlterTableAddConstraint(expr)
+            is AlterTableDropConstraintExpression -> visitAlterTableDropConstraint(expr)
+            is CreateIndexExpression -> visitCreateIndex(expr)
+            is DropIndexExpression -> visitDropIndex(expr)
+            is CreateViewExpression -> visitCreateView(expr)
+            is DropViewExpression -> visitDropView(expr)
+            is ColumnDeclarationExpression<*> -> visitColumnDeclaration(expr)
+            is ForeignKeyTableConstraintExpression -> visitForeignKeyTableConstraint(expr)
+            is CheckTableConstraintExpression -> visitCheckTableConstraint(expr)
+            is UniqueTableConstraintExpression -> visitUniqueTableConstraint(expr)
+            is PrimaryKeyTableConstraintExpression -> visitPrimaryKeyTableConstraint(expr)
+            is DefaultColumnConstraintExpression<*> -> visitDefaultColumnConstraint(expr)
+            is AutoIncrementColumnConstraintExpression<*> -> visitAutoIncrementColumnConstraint(expr)
+            else -> super.visit(expr)
+        }
+    }
+
+    protected open fun visitCreateTable(expr: CreateTableExpression): SqlExpression {
+        writeKeyword("create table ")
+        visitTableReference(expr.name)
+
+        write("(")
+        var first = true
+        for(col in expr.columns){
+            if(first) first = false
+            else write(", ")
+            visitColumnDeclaration(col)
+        }
+        for(constraint in expr.constraints.entries){
+            writeKeyword(", constraint ")
+            write(constraint.key)
+            write(" ")
+            visit(constraint.value)
+        }
+        write(") ")
+
+        return expr
+    }
+
+    protected open fun visitDropTable(expr: DropTableExpression): SqlExpression {
+        writeKeyword("drop table ")
+        visitTableReference(expr.table)
+        return expr
+    }
+
+    protected open fun visitTruncateTable(expr: TruncateTableExpression): SqlExpression {
+        writeKeyword("truncate table")
+        visitTableReference(expr.table)
+        return expr
+    }
+    protected open fun visitAlterTableAdd(expr: AlterTableAddExpression): SqlExpression = expr
+    protected open fun visitAlterTableDropColumn(expr: AlterTableDropColumnExpression): SqlExpression = expr
+    protected open fun visitAlterTableModifyColumn(expr: AlterTableModifyColumnExpression): SqlExpression = expr
+    protected open fun visitAlterTableSetColumnConstraint(expr: AlterTableSetColumnConstraintExpression<*>): SqlExpression = expr
+    protected open fun visitAlterTableDropColumnConstraint(expr: AlterTableDropColumnConstraintExpression): SqlExpression = expr
+    protected open fun visitAlterTableAddConstraint(expr: AlterTableAddConstraintExpression): SqlExpression = expr
+    protected open fun visitAlterTableDropConstraint(expr: AlterTableDropConstraintExpression): SqlExpression = expr
+    protected open fun visitCreateIndex(expr: CreateIndexExpression): SqlExpression = expr
+    protected open fun visitDropIndex(expr: DropIndexExpression): SqlExpression = expr
+    protected open fun visitCreateView(expr: CreateViewExpression): SqlExpression = expr
+    protected open fun visitDropView(expr: DropViewExpression): SqlExpression = expr
+
+    protected open fun visitColumnDeclaration(expr: ColumnDeclarationExpression<*>): SqlExpression {
+        write(expr.name)
+        write(" ")
+        writeKeyword(expr.sqlType.typeName)
+        for(constraint in expr.constraints){
+            write(" ")
+            visit(constraint)
+        }
+        return expr
+    }
+    protected open fun visitForeignKeyTableConstraint(expr: ForeignKeyTableConstraintExpression): SqlExpression {
+        writeKeyword("FOREIGN KEY (")
+        val orderedEntries = expr.correspondence.entries.toList()
+        var first = true
+        for(col in orderedEntries){
+            if(first) first = false
+            else write(", ")
+            write(col.key.name)
+        }
+        writeKeyword(") REFERENCES ")
+        visitTableReference(expr.otherTable)
+        write("(")
+        first = true
+        for(col in orderedEntries){
+            if(first) first = false
+            else write(", ")
+            write(col.value.name)
+        }
+        write(")")
+        return expr
+    }
+    protected open fun visitCheckTableConstraint(expr: CheckTableConstraintExpression): SqlExpression = expr
+    protected open fun visitUniqueTableConstraint(expr: UniqueTableConstraintExpression): SqlExpression = expr
+    protected open fun visitPrimaryKeyTableConstraint(expr: PrimaryKeyTableConstraintExpression): SqlExpression = expr
+    protected open fun visitPrimaryKeyColumnConstraint(expr: PrimaryKeyColumnConstraintExpression): SqlExpression {
+        writeKeyword("PRIMARY KEY")
+        return expr
+    }
+    protected open fun visitUniqueColumnConstraint(expr: UniqueColumnConstraintExpression): SqlExpression {
+        writeKeyword("UNIQUE")
+        return expr
+    }
+    protected open fun visitNotNullColumnConstraint(expr: NotNullColumnConstraintExpression): SqlExpression {
+        writeKeyword("NOT NULL")
+        return expr
+    }
+    protected open fun visitDefaultColumnConstraint(expr: DefaultColumnConstraintExpression<*>): SqlExpression {
+        writeKeyword("DEFAULT ")
+        visitScalar(expr.value)
+        return expr
+    }
+    protected open fun visitAutoIncrementColumnConstraint(expr: AutoIncrementColumnConstraintExpression<*>): SqlExpression = TODO()
+
+    protected open fun visitTableReference(expr: TableReferenceExpression): SqlExpression {
+        return visitTable(
+            TableExpression(
+                name = expr.name,
+                tableAlias = null,
+                catalog = expr.catalog,
+                schema = expr.schema,
+                isLeafNode = expr.isLeafNode,
+                extraProperties = expr.extraProperties
+            )
+        )
+    }
+}

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlSchemaFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlSchemaFormatter.kt
@@ -17,11 +17,9 @@
 package org.ktorm.expression
 
 import org.ktorm.database.Database
-import org.ktorm.database.DialectFeatureNotSupportedException
 
 /**
- * Subclass of [SqlExpressionVisitor], visiting SQL expression trees using visitor pattern. After the visit completes,
- * the executable SQL string will be generated in the [sql] property with its execution parameters in [parameters].
+ * Subclass of [SqlFormatter] that is able to write information about migrations.
  *
  * @property database the current database object used to obtain metadata such as identifier quote string.
  * @property beautifySql mark if we should output beautiful SQL strings with line-wrapping and indentation.
@@ -29,7 +27,6 @@ import org.ktorm.database.DialectFeatureNotSupportedException
  * @property sql return the executable SQL string after the visit completes.
  * @property parameters return the SQL's execution parameters after the visit completes.
  */
-@Suppress("VariableNaming")
 public abstract class SqlSchemaFormatter(
     database: Database,
     beautifySql: Boolean,

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlSchemaFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlSchemaFormatter.kt
@@ -100,17 +100,17 @@ public abstract class SqlSchemaFormatter(
         visitTableReference(expr.table)
         return expr
     }
-    protected open fun visitAlterTableAdd(expr: AlterTableAddExpression): SqlExpression = expr
-    protected open fun visitAlterTableDropColumn(expr: AlterTableDropColumnExpression): SqlExpression = expr
-    protected open fun visitAlterTableModifyColumn(expr: AlterTableModifyColumnExpression): SqlExpression = expr
-    protected open fun visitAlterTableSetColumnConstraint(expr: AlterTableSetColumnConstraintExpression<*>): SqlExpression = expr
-    protected open fun visitAlterTableDropColumnConstraint(expr: AlterTableDropColumnConstraintExpression): SqlExpression = expr
-    protected open fun visitAlterTableAddConstraint(expr: AlterTableAddConstraintExpression): SqlExpression = expr
-    protected open fun visitAlterTableDropConstraint(expr: AlterTableDropConstraintExpression): SqlExpression = expr
-    protected open fun visitCreateIndex(expr: CreateIndexExpression): SqlExpression = expr
-    protected open fun visitDropIndex(expr: DropIndexExpression): SqlExpression = expr
-    protected open fun visitCreateView(expr: CreateViewExpression): SqlExpression = expr
-    protected open fun visitDropView(expr: DropViewExpression): SqlExpression = expr
+    protected open fun visitAlterTableAdd(expr: AlterTableAddExpression): SqlExpression = TODO()
+    protected open fun visitAlterTableDropColumn(expr: AlterTableDropColumnExpression): SqlExpression = TODO()
+    protected open fun visitAlterTableModifyColumn(expr: AlterTableModifyColumnExpression): SqlExpression = TODO()
+    protected open fun visitAlterTableSetColumnConstraint(expr: AlterTableSetColumnConstraintExpression<*>): SqlExpression = TODO()
+    protected open fun visitAlterTableDropColumnConstraint(expr: AlterTableDropColumnConstraintExpression): SqlExpression = TODO()
+    protected open fun visitAlterTableAddConstraint(expr: AlterTableAddConstraintExpression): SqlExpression = TODO()
+    protected open fun visitAlterTableDropConstraint(expr: AlterTableDropConstraintExpression): SqlExpression = TODO()
+    protected open fun visitCreateIndex(expr: CreateIndexExpression): SqlExpression = TODO()
+    protected open fun visitDropIndex(expr: DropIndexExpression): SqlExpression = TODO()
+    protected open fun visitCreateView(expr: CreateViewExpression): SqlExpression = TODO()
+    protected open fun visitDropView(expr: DropViewExpression): SqlExpression = TODO()
 
     protected open fun visitColumnDeclaration(expr: ColumnDeclarationExpression<*>): SqlExpression {
         write(expr.name)
@@ -143,9 +143,9 @@ public abstract class SqlSchemaFormatter(
         write(")")
         return expr
     }
-    protected open fun visitCheckTableConstraint(expr: CheckTableConstraintExpression): SqlExpression = expr
-    protected open fun visitUniqueTableConstraint(expr: UniqueTableConstraintExpression): SqlExpression = expr
-    protected open fun visitPrimaryKeyTableConstraint(expr: PrimaryKeyTableConstraintExpression): SqlExpression = expr
+    protected open fun visitCheckTableConstraint(expr: CheckTableConstraintExpression): SqlExpression = TODO()
+    protected open fun visitUniqueTableConstraint(expr: UniqueTableConstraintExpression): SqlExpression = TODO()
+    protected open fun visitPrimaryKeyTableConstraint(expr: PrimaryKeyTableConstraintExpression): SqlExpression = TODO()
     protected open fun visitPrimaryKeyColumnConstraint(expr: PrimaryKeyColumnConstraintExpression): SqlExpression {
         writeKeyword("PRIMARY KEY")
         return expr

--- a/ktorm-core/src/main/kotlin/org/ktorm/schema/Column.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/schema/Column.kt
@@ -106,7 +106,12 @@ public data class Column<T : Any>(
     /**
      * The [SqlType] of this column or expression.
      */
-    override val sqlType: SqlType<T>
+    override val sqlType: SqlType<T>,
+
+    /**
+     * Any [Constraint]s that apply to this column.
+     */
+    val constraints: List<Constraint<T>> = listOf()
 
 ) : ColumnDeclaring<T> {
 
@@ -192,3 +197,9 @@ public data class Column<T : Any>(
         return System.identityHashCode(this)
     }
 }
+
+public abstract class Constraint<in T>() {}
+public data class ForeignKeyConstraint(val to: BaseTable<*>, val on: Column<*>): Constraint<Any>()
+public data class DefaultConstraint<T: Any>(val value: ScalarExpression<T>): Constraint<Any>()
+public object NotNullConstraint: Constraint<Any>()
+public object UniqueConstraint: Constraint<Any>()

--- a/ktorm-core/src/main/kotlin/org/ktorm/schema/create.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/schema/create.kt
@@ -1,0 +1,62 @@
+//TODO: This file needs to be renamed to something else
+
+
+package org.ktorm.schema
+
+import org.ktorm.expression.*
+
+public fun BaseTable<*>.createTable(): CreateTableExpression {
+    val tableConstraints = HashMap<String, TableConstraintExpression>()
+    return CreateTableExpression(
+        name = this.asReferenceExpression(),
+        columns = this.columns.map {
+            ColumnDeclarationExpression(
+                name = it.name,
+                sqlType = it.sqlType,
+                constraints = mutableListOf<ColumnConstraintExpression<Any>>().apply {
+                    if(primaryKeys.contains(it)) add(PrimaryKeyColumnConstraintExpression)
+                    if(it.binding is ReferenceBinding) {
+                        tableConstraints["FK_" + it.name] = (ForeignKeyTableConstraintExpression(
+                            otherTable = it.binding.referenceTable.asReferenceExpression(),
+                            correspondence = mapOf(
+                                it.asExpression() to it.binding.referenceTable.singlePrimaryKey {
+                                    "Doesn't work on multiple PKs"
+                                }.asExpression()
+                            )
+                        ))
+                    }
+                    for(extra in it.extraBindings){
+                        if(extra is ReferenceBinding) {
+                            tableConstraints["FK_" + it.name] = (ForeignKeyTableConstraintExpression(
+                                otherTable = extra.referenceTable.asReferenceExpression(),
+                                correspondence = mapOf(
+                                    it.asExpression() to extra.referenceTable.singlePrimaryKey {
+                                        "Doesn't work on multiple PKs"
+                                    }.asExpression()
+                                )
+                            ))
+                        }
+                    }
+                    for(constraint in it.constraints){
+                        when(constraint){
+                            UniqueConstraint -> add(UniqueColumnConstraintExpression)
+                            NotNullConstraint -> add(NotNullColumnConstraintExpression)
+                            is DefaultConstraint<*>-> @Suppress("UNCHECKED_CAST") add(
+                                DefaultColumnConstraintExpression(constraint.value) as ColumnConstraintExpression<Any>
+                            )
+                            is ForeignKeyConstraint -> {
+                                tableConstraints["FK_" + it.name] = (ForeignKeyTableConstraintExpression(
+                                    otherTable = constraint.to.asReferenceExpression(),
+                                    correspondence = mapOf(
+                                        it.asExpression() to constraint.on.asExpression()
+                                    )
+                                ))
+                            }
+                        }
+                    }
+                }
+            )
+        },
+        constraints = tableConstraints
+    )
+}

--- a/ktorm-core/src/test/kotlin/org/ktorm/expression/SchemaTest.kt
+++ b/ktorm-core/src/test/kotlin/org/ktorm/expression/SchemaTest.kt
@@ -1,10 +1,11 @@
-package org.ktorm
+package org.ktorm.expression
 
-import org.junit.After
 import org.junit.Before
+import org.junit.Test
 import org.ktorm.database.Database
 import org.ktorm.database.SqlDialect
-import org.ktorm.database.use
+import org.ktorm.dsl.default
+import org.ktorm.dsl.unique
 import org.ktorm.entity.Entity
 import org.ktorm.entity.sequenceOf
 import org.ktorm.logging.ConsoleLogger
@@ -16,45 +17,45 @@ import java.time.LocalDate
 /**
  * Created by vince on Dec 07, 2018.
  */
-open class BaseTest {
+open class SchemaTest {
     lateinit var database: Database
-
-    object TestDialect: SqlDialect{}
 
     @Before
     open fun init() {
         database = Database.connect(
-            dialect = TestDialect,
+            dialect = object : SqlDialect {
+                override fun createSqlFormatter(
+                    database: Database,
+                    beautifySql: Boolean,
+                    indentSize: Int
+                ): SqlFormatter {
+                    return TestFormatter(database, beautifySql, indentSize)
+                }
+            },
             url = "jdbc:h2:mem:ktorm;DB_CLOSE_DELAY=-1",
             driver = "org.h2.Driver",
             logger = ConsoleLogger(threshold = LogLevel.TRACE),
             alwaysQuoteIdentifiers = true
         )
-
-        execSqlScript("init-data.sql")
     }
 
-    @After
-    open fun destroy() {
-        execSqlScript("drop-data.sql")
+    @Test
+    fun create(){
+        val fmt = TestFormatter(database, true, 2)
+        database.executeUpdate(Departments.createTable())
+        database.executeUpdate(Employees.createTable())
     }
 
-    protected fun execSqlScript(filename: String) {
-        database.useConnection { conn ->
-            conn.createStatement().use { statement ->
-                javaClass.classLoader
-                    ?.getResourceAsStream(filename)
-                    ?.bufferedReader()
-                    ?.use { reader ->
-                        for (sql in reader.readText().split(';')) {
-                            if (sql.any { it.isLetterOrDigit() }) {
-                                statement.executeUpdate(sql)
-                            }
-                        }
-                    }
-            }
+    class TestFormatter(
+        database: Database,
+        beautifySql: Boolean,
+        indentSize: Int
+    ) : SqlSchemaFormatter(database, beautifySql, indentSize) {
+        override fun writePagination(expr: QueryExpression) {
+            TODO("Not yet implemented")
         }
     }
+
 
     data class LocationWrapper(val underlying: String = ""): Serializable
 
@@ -103,8 +104,8 @@ open class BaseTest {
         override fun aliased(alias: String) = Employees(alias)
 
         val id = int("id").primaryKey().bindTo { it.id }
-        val name = varchar("name").bindTo { it.name }
-        val job = varchar("job").bindTo { it.job }
+        val name = varchar("name").unique().bindTo { it.name }
+        val job = varchar("job").default("Minion").bindTo { it.job }
         val managerId = int("manager_id").bindTo { it.manager?.id }
         val hireDate = date("hire_date").bindTo { it.hireDate }
         val salary = long("salary").bindTo { it.salary }


### PR DESCRIPTION
This is a work-in-progress PR for supporting migrations in Ktorm. (issue #64)

I figured I'd put this up earlier rather than later so that you could review it and set me on your desired path for the implementation, rather than submitting something complete that didn't suit the project.

I have attempted to follow the standards already set by defining these operations as `SqlExpression`s.  However, I thought it might be best to integrate constraints directly within `BaseTable`.

The general plan is this:
- Migrations are Kotlin files in your project that run the needed modifications to the database, and optionally can do more.
- These migrations are auto-generated by running a function, which the user will likely want to do from their `main()` function when certain args are passed in.  Alternatively, one could use a different `main` entrypoint.
- There is an automatically updated `AllMigrations.kt` file that references the latest migration files
- Migration files reference their previous migrations, creating a full dependency chain
- Migration status (which migrations have been run) is stored inside of a special table inside of the database

Known items needed:
- Doc comments on everything
- More tests
- Actually making and running the migrations
- Support for each individual dialect
- Size of VARCHAR stored in the column