### PR TITLE
Separate Database into interface and implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,11 @@ subprojects { project ->
                             name = "Eric Fenderbosch"
                             email = "eric@fender.net"
                         }
+                        developer {
+                            id = "ecopoesis"
+                            name = "Mike Roberts"
+                            email = "miker@miker.org"
+                        }
                     }
                 }
             }

--- a/ktorm-core/src/main/kotlin/org/ktorm/database/Database.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/database/Database.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ktorm.database
 
 import org.ktorm.dsl.Query

--- a/ktorm-core/src/main/kotlin/org/ktorm/database/Database.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/database/Database.kt
@@ -461,11 +461,10 @@ public inline fun <T> Database.useConnection(func: (Connection) -> T): T {
     }
 }
 
-
 /**
  * Execute the specific callback function in a transaction and returns its result if the execution succeeds,
  * otherwise, if the execution fails, the transaction will be rollback.
- *
+ *P
  * Note:
  *
  * - Any exceptions thrown in the callback function can trigger a rollback.

--- a/ktorm-core/src/main/kotlin/org/ktorm/database/Database.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/database/Database.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018-2021 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.ktorm.database
 
 import org.ktorm.dsl.Query
@@ -25,11 +9,14 @@ import org.ktorm.logging.detectLoggerImplementation
 import org.springframework.dao.DataAccessException
 import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator
 import org.springframework.transaction.annotation.Transactional
-import java.sql.*
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
 import java.util.*
 import javax.sql.DataSource
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
+import kotlin.contracts.InvocationKind.EXACTLY_ONCE
 import kotlin.contracts.contract
 
 /**
@@ -99,34 +86,33 @@ import kotlin.contracts.contract
  * ```
  * More details about SQL DSL, see [Query], about sequence APIs, see [EntitySequence].
  */
-public class Database(
-
+public interface Database {
     /**
      * The transaction manager used to manage connections and transactions.
      */
-    public val transactionManager: TransactionManager,
+    public val transactionManager: TransactionManager
 
     /**
      * The dialect, auto detects an implementation by default using JDK [ServiceLoader] facility.
      */
-    public val dialect: SqlDialect = detectDialectImplementation(),
+    public val dialect: SqlDialect
 
     /**
      * The logger used to output logs, auto detects an implementation by default.
      */
-    public val logger: Logger = detectLoggerImplementation(),
+    public val logger: Logger
 
     /**
      * Function used to translate SQL exceptions so as to rethrow them to users.
      */
-    public val exceptionTranslator: ((SQLException) -> Throwable)? = null,
+    public val exceptionTranslator: ((SQLException) -> Throwable)?
 
     /**
      * Whether we need to always quote SQL identifiers in the generated SQLs.
      *
      * @since 3.1.0
      */
-    public val alwaysQuoteIdentifiers: Boolean = false,
+    public val alwaysQuoteIdentifiers: Boolean
 
     /**
      * Whether we need to output the generated SQLs in upper case.
@@ -135,8 +121,8 @@ public class Database(
      *
      * @since 3.1.0
      */
-    public val generateSqlInUpperCase: Boolean? = null
-) {
+    public val generateSqlInUpperCase: Boolean?
+
     /**
      * The URL of the connected database.
      */
@@ -244,113 +230,6 @@ public class Database(
      */
     public val maxColumnNameLength: Int
 
-    init {
-        fun Result<String?>.orEmpty() = getOrNull().orEmpty()
-        fun Result<Boolean>.orFalse() = getOrDefault(false)
-
-        useConnection { conn ->
-            val metadata = conn.metaData
-            url = metadata.runCatching { url }.orEmpty()
-            name = url.substringAfterLast('/').substringBefore('?')
-            productName = metadata.runCatching { databaseProductName }.orEmpty()
-            productVersion = metadata.runCatching { databaseProductVersion }.orEmpty()
-            keywords = ANSI_SQL_2003_KEYWORDS + metadata.runCatching { sqlKeywords }.orEmpty().toUpperCase().split(',')
-            identifierQuoteString = metadata.runCatching { identifierQuoteString }.orEmpty().trim()
-            extraNameCharacters = metadata.runCatching { extraNameCharacters }.orEmpty()
-            supportsMixedCaseIdentifiers = metadata.runCatching { supportsMixedCaseIdentifiers() }.orFalse()
-            storesMixedCaseIdentifiers = metadata.runCatching { storesMixedCaseIdentifiers() }.orFalse()
-            storesUpperCaseIdentifiers = metadata.runCatching { storesUpperCaseIdentifiers() }.orFalse()
-            storesLowerCaseIdentifiers = metadata.runCatching { storesLowerCaseIdentifiers() }.orFalse()
-            supportsMixedCaseQuotedIdentifiers = metadata.runCatching { supportsMixedCaseQuotedIdentifiers() }.orFalse()
-            storesMixedCaseQuotedIdentifiers = metadata.runCatching { storesMixedCaseQuotedIdentifiers() }.orFalse()
-            storesUpperCaseQuotedIdentifiers = metadata.runCatching { storesUpperCaseQuotedIdentifiers() }.orFalse()
-            storesLowerCaseQuotedIdentifiers = metadata.runCatching { storesLowerCaseQuotedIdentifiers() }.orFalse()
-            maxColumnNameLength = metadata.runCatching { maxColumnNameLength }.getOrDefault(0)
-        }
-
-        if (logger.isInfoEnabled()) {
-            val msg = "Connected to %s, productName: %s, productVersion: %s, logger: %s, dialect: %s"
-            logger.info(msg.format(url, productName, productVersion, logger, dialect))
-        }
-    }
-
-    /**
-     * Obtain a connection and invoke the callback function with it.
-     *
-     * If the current thread has opened a transaction, then this transaction's connection will be used.
-     * Otherwise, Ktorm will pass a new-created connection to the function and auto close it after it's
-     * not useful anymore.
-     *
-     * @param func the executed callback function.
-     * @return the result of the callback function.
-     */
-    @OptIn(ExperimentalContracts::class)
-    public inline fun <T> useConnection(func: (Connection) -> T): T {
-        contract {
-            callsInPlace(func, InvocationKind.EXACTLY_ONCE)
-        }
-
-        try {
-            val transaction = transactionManager.currentTransaction
-            val connection = transaction?.connection ?: transactionManager.newConnection()
-
-            try {
-                return func(connection)
-            } finally {
-                if (transaction == null) connection.close()
-            }
-        } catch (e: SQLException) {
-            throw exceptionTranslator?.invoke(e) ?: e
-        }
-    }
-
-    /**
-     * Execute the specific callback function in a transaction and returns its result if the execution succeeds,
-     * otherwise, if the execution fails, the transaction will be rollback.
-     *
-     * Note:
-     *
-     * - Any exceptions thrown in the callback function can trigger a rollback.
-     * - This function is reentrant, so it can be called nested. However, the inner calls don’t open new transactions
-     * but share the same ones with outers.
-     * - Since version 3.3.0, the default isolation has changed to null (stands for the default isolation level of the
-     * underlying datastore), not [TransactionIsolation.REPEATABLE_READ] anymore.
-     *
-     * @param isolation transaction isolation, null for the default isolation level of the underlying datastore.
-     * @param func the executed callback function.
-     * @return the result of the callback function.
-     */
-    @OptIn(ExperimentalContracts::class)
-    public inline fun <T> useTransaction(isolation: TransactionIsolation? = null, func: (Transaction) -> T): T {
-        contract {
-            callsInPlace(func, InvocationKind.EXACTLY_ONCE)
-        }
-
-        val current = transactionManager.currentTransaction
-        val isOuter = current == null
-        val transaction = current ?: transactionManager.newTransaction(isolation)
-        var throwable: Throwable? = null
-
-        try {
-            return func(transaction)
-        } catch (e: SQLException) {
-            throwable = exceptionTranslator?.invoke(e) ?: e
-            throw throwable
-        } catch (e: Throwable) {
-            throwable = e
-            throw throwable
-        } finally {
-            if (isOuter) {
-                @Suppress("ConvertTryFinallyToUseCall")
-                try {
-                    if (throwable == null) transaction.commit() else transaction.rollback()
-                } finally {
-                    transaction.close()
-                }
-            }
-        }
-    }
-
     /**
      * Format the specific [SqlExpression] to an executable SQL string with execution arguments.
      *
@@ -363,43 +242,7 @@ public class Database(
         expression: SqlExpression,
         beautifySql: Boolean = false,
         indentSize: Int = 2
-    ): Pair<String, List<ArgumentExpression<*>>> {
-        val formatter = dialect.createSqlFormatter(this, beautifySql, indentSize)
-        formatter.visit(expression)
-        return Pair(formatter.sql, formatter.parameters)
-    }
-
-    /**
-     * Format the given [expression] to a SQL string with its execution arguments, then create
-     * a [PreparedStatement] from the this database using the SQL string and execute the specific
-     * callback function with it. After the callback function completes, the statement will be
-     * closed automatically.
-     *
-     * @since 2.7
-     * @param expression the SQL expression to be executed.
-     * @param func the callback function.
-     * @return the result of the callback function.
-     */
-    @OptIn(ExperimentalContracts::class)
-    public inline fun <T> executeExpression(expression: SqlExpression, func: (PreparedStatement) -> T): T {
-        contract {
-            callsInPlace(func, InvocationKind.EXACTLY_ONCE)
-        }
-
-        val (sql, args) = formatExpression(expression)
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("SQL: $sql")
-            logger.debug("Parameters: " + args.map { "${it.value}(${it.sqlType.typeName})" })
-        }
-
-        useConnection { conn ->
-            conn.prepareStatement(sql).use { statement ->
-                statement.setArguments(args)
-                return func(statement)
-            }
-        }
-    }
+    ): Pair<String, List<ArgumentExpression<*>>>
 
     /**
      * Format the given [expression] to a SQL string with its execution arguments, then execute it via
@@ -409,19 +252,7 @@ public class Database(
      * @param expression the SQL expression to be executed.
      * @return the result [CachedRowSet].
      */
-    public fun executeQuery(expression: SqlExpression): CachedRowSet {
-        executeExpression(expression) { statement ->
-            statement.executeQuery().use { rs ->
-                val rowSet = CachedRowSet(rs)
-
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Results: ${rowSet.size()}")
-                }
-
-                return rowSet
-            }
-        }
-    }
+    public fun executeQuery(expression: SqlExpression): CachedRowSet
 
     /**
      * Format the given [expression] to a SQL string with its execution arguments, then execute it via
@@ -431,17 +262,7 @@ public class Database(
      * @param expression the SQL expression to be executed.
      * @return the effected row count.
      */
-    public fun executeUpdate(expression: SqlExpression): Int {
-        executeExpression(expression) { statement ->
-            val effects = statement.executeUpdate()
-
-            if (logger.isDebugEnabled()) {
-                logger.debug("Effects: $effects")
-            }
-
-            return effects
-        }
-    }
+    public fun executeUpdate(expression: SqlExpression): Int
 
     /**
      * Format the given [expression] to a SQL string with its execution arguments, execute it via
@@ -451,22 +272,7 @@ public class Database(
      * @param expression the SQL expression to be executed.
      * @return a [Pair] combines the effected row count and the generated keys.
      */
-    public fun executeUpdateAndRetrieveKeys(expression: SqlExpression): Pair<Int, CachedRowSet> {
-        val (sql, args) = formatExpression(expression)
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("SQL: $sql")
-            logger.debug("Parameters: " + args.map { "${it.value}(${it.sqlType.typeName})" })
-        }
-
-        val (effects, rowSet) = dialect.executeUpdateAndRetrieveKeys(this, sql, args)
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("Effects: $effects")
-        }
-
-        return Pair(effects, rowSet)
-    }
+    public fun executeUpdateAndRetrieveKeys(expression: SqlExpression): Pair<Int, CachedRowSet>
 
     /**
      * Batch execute the given SQL expressions and return the effected row counts for each expression.
@@ -478,41 +284,7 @@ public class Database(
      * @param expressions the SQL expressions to be executed.
      * @return the effected row counts for each sub-operation.
      */
-    public fun executeBatch(expressions: List<SqlExpression>): IntArray {
-        val (sql, _) = formatExpression(expressions[0])
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("SQL: $sql")
-        }
-
-        useConnection { conn ->
-            conn.prepareStatement(sql).use { statement ->
-                for (expr in expressions) {
-                    val (subSql, args) = formatExpression(expr)
-
-                    if (subSql != sql) {
-                        throw IllegalArgumentException(
-                            "Every item in a batch operation must generate the same SQL: \n\n$subSql"
-                        )
-                    }
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Parameters: " + args.map { "${it.value}(${it.sqlType.typeName})" })
-                    }
-
-                    statement.setArguments(args)
-                    statement.addBatch()
-                }
-
-                val effects = statement.executeBatch()
-
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Effects: ${effects?.contentToString()}")
-                }
-
-                return effects
-            }
-        }
-    }
+    public fun executeBatch(expressions: List<SqlExpression>): IntArray
 
     /**
      * Companion object provides functions to connect to databases.
@@ -536,7 +308,7 @@ public class Database(
             generateSqlInUpperCase: Boolean? = null,
             connector: () -> Connection
         ): Database {
-            return Database(
+            return DatabaseImpl(
                 transactionManager = JdbcTransactionManager(connector),
                 dialect = dialect,
                 logger = logger,
@@ -562,7 +334,7 @@ public class Database(
             alwaysQuoteIdentifiers: Boolean = false,
             generateSqlInUpperCase: Boolean? = null
         ): Database {
-            return Database(
+            return DatabaseImpl(
                 transactionManager = JdbcTransactionManager { dataSource.connection },
                 dialect = dialect,
                 logger = logger,
@@ -598,7 +370,7 @@ public class Database(
                 Class.forName(driver)
             }
 
-            return Database(
+            return DatabaseImpl(
                 transactionManager = JdbcTransactionManager { DriverManager.getConnection(url, user, password) },
                 dialect = dialect,
                 logger = logger,
@@ -632,7 +404,7 @@ public class Database(
             generateSqlInUpperCase: Boolean? = null
         ): Database {
             val translator = SQLErrorCodeSQLExceptionTranslator(dataSource)
-            return Database(
+            return DatabaseImpl(
                 transactionManager = SpringManagedTransactionManager(dataSource),
                 dialect = dialect,
                 logger = logger,
@@ -640,6 +412,83 @@ public class Database(
                 alwaysQuoteIdentifiers = alwaysQuoteIdentifiers,
                 generateSqlInUpperCase = generateSqlInUpperCase
             )
+        }
+    }
+}
+
+/**
+ * Obtain a connection and invoke the callback function with it.
+ *
+ * If the current thread has opened a transaction, then this transaction's connection will be used.
+ * Otherwise, Ktorm will pass a new-created connection to the function and auto close it after it's
+ * not useful anymore.
+ *
+ * @param func the executed callback function.
+ * @return the result of the callback function.
+ */
+@OptIn(ExperimentalContracts::class)
+public inline fun <T> Database.useConnection(func: (Connection) -> T): T {
+    contract {
+        callsInPlace(func, EXACTLY_ONCE)
+    }
+    try {
+        val transaction = transactionManager.currentTransaction
+        val connection = transaction?.connection ?: transactionManager.newConnection()
+
+        try {
+            return func(connection)
+        } finally {
+            if (transaction == null) connection.close()
+        }
+    } catch (e: SQLException) {
+        throw exceptionTranslator?.invoke(e) ?: e
+    }
+}
+
+
+/**
+ * Execute the specific callback function in a transaction and returns its result if the execution succeeds,
+ * otherwise, if the execution fails, the transaction will be rollback.
+ *
+ * Note:
+ *
+ * - Any exceptions thrown in the callback function can trigger a rollback.
+ * - This function is reentrant, so it can be called nested. However, the inner calls don’t open new transactions
+ * but share the same ones with outers.
+ * - Since version 3.3.0, the default isolation has changed to null (stands for the default isolation level of the
+ * underlying datastore), not [TransactionIsolation.REPEATABLE_READ] anymore.
+ *
+ * @param isolation transaction isolation, null for the default isolation level of the underlying datastore.
+ * @param func the executed callback function.
+ * @return the result of the callback function.
+ */
+@OptIn(ExperimentalContracts::class)
+public inline fun <T> Database.useTransaction(isolation: TransactionIsolation? = null, func: (Transaction) -> T): T {
+    contract {
+        callsInPlace(func, InvocationKind.EXACTLY_ONCE)
+    }
+
+    val current = transactionManager.currentTransaction
+    val isOuter = current == null
+    val transaction = current ?: transactionManager.newTransaction(isolation)
+    var throwable: Throwable? = null
+
+    try {
+        return func(transaction)
+    } catch (e: SQLException) {
+        throwable = exceptionTranslator?.invoke(e) ?: e
+        throw throwable
+    } catch (e: Throwable) {
+        throwable = e
+        throw throwable
+    } finally {
+        if (isOuter) {
+            @Suppress("ConvertTryFinallyToUseCall")
+            try {
+                if (throwable == null) transaction.commit() else transaction.rollback()
+            } finally {
+                transaction.close()
+            }
         }
     }
 }

--- a/ktorm-core/src/main/kotlin/org/ktorm/database/DatabaseImpl.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/database/DatabaseImpl.kt
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.database
+
+import org.ktorm.dsl.Query
+import org.ktorm.entity.EntitySequence
+import org.ktorm.expression.ArgumentExpression
+import org.ktorm.expression.SqlExpression
+import org.ktorm.logging.Logger
+import org.ktorm.logging.detectLoggerImplementation
+import java.sql.*
+import java.util.*
+import javax.sql.DataSource
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * The entry class of Ktorm, represents a physical database, used to manage connections and transactions.
+ *
+ * ### Connect with a URL
+ *
+ * The simplest way to create a database instance, using a JDBC URL:
+ *
+ * ```kotlin
+ * val database = Database.connect("jdbc:mysql://localhost:3306/ktorm", user = "root", password = "123")
+ * ```
+ *
+ * Easy to know what we do in the [connect] function. Just like any JDBC boilerplate code, Ktorm loads the MySQL
+ * database driver first, then calls [DriverManager.getConnection] with your URL to obtain a connection.
+ *
+ * Of course, Ktorm doesn't call [DriverManager.getConnection] in the beginning. Instead, we obtain connections
+ * only when it's really needed (such as executing a SQL), then close them after they are not useful anymore.
+ * Therefore, database objects created by this way won't reuse any connections, creating connections frequently
+ * can lead to huge performance costs. It's highly recommended to use connection pools in your production environment.
+ *
+ * ### Connect with a Pool
+ *
+ * Ktorm doesn't limit you, you can use any connection pool you like, such as DBCP, C3P0 or Druid. The [connect]
+ * function provides an overloaded version which accepts a [DataSource] parameter, you just need to create a
+ * [DataSource] object and call that function with it:
+ *
+ * ```kotlin
+ * val dataSource = SingleConnectionDataSource() // Any DataSource implementation is OK.
+ * val database = Database.connect(dataSource)
+ * ```
+ *
+ * Now, Ktorm will obtain connections from the [DataSource] when necessary, then return them to the pool after they
+ * are not useful. This avoids the performance costs of frequent connection creation.
+ *
+ * Connection pools are applicative and effective in most cases, we highly recommend you manage your connections
+ * in this way.
+ *
+ * ### Use SQL DSL & Sequence APIs
+ *
+ * Now that we've connected to the database, we can perform many operations on it. Ktorm's APIs are mainly divided
+ * into two parts, they are SQL DSL and sequence APIs.
+ *
+ * Here, we use SQL DSL to obtains the names of all engineers in department 1:
+ *
+ * ```kotlin
+ * database
+ *     .from(Employees)
+ *     .select(Employees.name)
+ *     .where { (Employees.departmentId eq 1) and (Employees.job eq "engineer") }
+ *     .forEach { row ->
+ *         println(row[Employees.name])
+ *     }
+ * ```
+ *
+ * Equivalent code using sequence APIs:
+ *
+ * ```kotlin
+ * database
+ *     .sequenceOf(Employees)
+ *     .filter { it.departmentId eq 1 }
+ *     .filter { it.job eq "engineer" }
+ *     .mapColumns { it.name }
+ *     .forEach { name ->
+ *         println(name)
+ *     }
+ * ```
+ * More details about SQL DSL, see [Query], about sequence APIs, see [EntitySequence].
+ */
+public class DatabaseImpl(
+
+    /**
+     * The transaction manager used to manage connections and transactions.
+     */
+    override val transactionManager: TransactionManager,
+
+    /**
+     * The dialect, auto detects an implementation by default using JDK [ServiceLoader] facility.
+     */
+    override val dialect: SqlDialect = detectDialectImplementation(),
+
+    /**
+     * The logger used to output logs, auto detects an implementation by default.
+     */
+    override val logger: Logger = detectLoggerImplementation(),
+
+    /**
+     * Function used to translate SQL exceptions so as to rethrow them to users.
+     */
+    override val exceptionTranslator: ((SQLException) -> Throwable)? = null,
+
+    /**
+     * Whether we need to always quote SQL identifiers in the generated SQLs.
+     *
+     * @since 3.1.0
+     */
+    override val alwaysQuoteIdentifiers: Boolean = false,
+
+    /**
+     * Whether we need to output the generated SQLs in upper case.
+     *
+     * `true` for upper case, `false` for lower case, `null` for default (the database preferred style).
+     *
+     * @since 3.1.0
+     */
+    override val generateSqlInUpperCase: Boolean? = null
+) : Database {
+    /**
+     * The URL of the connected database.
+     */
+    override val url: String
+
+    /**
+     * The name of the connected database.
+     */
+    override val name: String
+
+    /**
+     * The name of the connected database product, eg. MySQL, H2.
+     */
+    override val productName: String
+
+    /**
+     * The version of the connected database product.
+     */
+    override val productVersion: String
+
+    /**
+     * A set of all of this database's SQL keywords (including SQL:2003 keywords), all in uppercase.
+     */
+    override val keywords: Set<String>
+
+    /**
+     * The string used to quote SQL identifiers, returns an empty string if identifier quoting is not supported.
+     */
+    override val identifierQuoteString: String
+
+    /**
+     * All the "extra" characters that can be used in unquoted identifier names (those beyond a-z, A-Z, 0-9 and _).
+     */
+    override val extraNameCharacters: String
+
+    /**
+     * Whether this database treats mixed case unquoted SQL identifiers as case sensitive and as a result
+     * stores them in mixed case.
+     *
+     * @since 3.1.0
+     */
+    override val supportsMixedCaseIdentifiers: Boolean
+
+    /**
+     * Whether this database treats mixed case unquoted SQL identifiers as case insensitive and
+     * stores them in mixed case.
+     *
+     * @since 3.1.0
+     */
+    override val storesMixedCaseIdentifiers: Boolean
+
+    /**
+     * Whether this database treats mixed case unquoted SQL identifiers as case insensitive and
+     * stores them in upper case.
+     *
+     * @since 3.1.0
+     */
+    override val storesUpperCaseIdentifiers: Boolean
+
+    /**
+     * Whether this database treats mixed case unquoted SQL identifiers as case insensitive and
+     * stores them in lower case.
+     *
+     * @since 3.1.0
+     */
+    override val storesLowerCaseIdentifiers: Boolean
+
+    /**
+     * Whether this database treats mixed case quoted SQL identifiers as case sensitive and as a result
+     * stores them in mixed case.
+     *
+     * @since 3.1.0
+     */
+    override val supportsMixedCaseQuotedIdentifiers: Boolean
+
+    /**
+     * Whether this database treats mixed case quoted SQL identifiers as case insensitive and
+     * stores them in mixed case.
+     *
+     * @since 3.1.0
+     */
+    override val storesMixedCaseQuotedIdentifiers: Boolean
+
+    /**
+     * Whether this database treats mixed case quoted SQL identifiers as case insensitive and
+     * stores them in upper case.
+     *
+     * @since 3.1.0
+     */
+    override val storesUpperCaseQuotedIdentifiers: Boolean
+
+    /**
+     * Whether this database treats mixed case quoted SQL identifiers as case insensitive and
+     * stores them in lower case.
+     *
+     * @since 3.1.0
+     */
+    override val storesLowerCaseQuotedIdentifiers: Boolean
+
+    /**
+     * The maximum number of characters this database allows for a column name. Zero means that there is no limit
+     * or the limit is not known.
+     *
+     * @since 3.1.0
+     */
+    override val maxColumnNameLength: Int
+
+    init {
+        fun Result<String?>.orEmpty() = getOrNull().orEmpty()
+        fun Result<Boolean>.orFalse() = getOrDefault(false)
+
+        useConnection { conn ->
+            val metadata = conn.metaData
+            url = metadata.runCatching { url }.orEmpty()
+            name = url.substringAfterLast('/').substringBefore('?')
+            productName = metadata.runCatching { databaseProductName }.orEmpty()
+            productVersion = metadata.runCatching { databaseProductVersion }.orEmpty()
+            keywords = ANSI_SQL_2003_KEYWORDS + metadata.runCatching { sqlKeywords }.orEmpty().toUpperCase().split(',')
+            identifierQuoteString = metadata.runCatching { identifierQuoteString }.orEmpty().trim()
+            extraNameCharacters = metadata.runCatching { extraNameCharacters }.orEmpty()
+            supportsMixedCaseIdentifiers = metadata.runCatching { supportsMixedCaseIdentifiers() }.orFalse()
+            storesMixedCaseIdentifiers = metadata.runCatching { storesMixedCaseIdentifiers() }.orFalse()
+            storesUpperCaseIdentifiers = metadata.runCatching { storesUpperCaseIdentifiers() }.orFalse()
+            storesLowerCaseIdentifiers = metadata.runCatching { storesLowerCaseIdentifiers() }.orFalse()
+            supportsMixedCaseQuotedIdentifiers = metadata.runCatching { supportsMixedCaseQuotedIdentifiers() }.orFalse()
+            storesMixedCaseQuotedIdentifiers = metadata.runCatching { storesMixedCaseQuotedIdentifiers() }.orFalse()
+            storesUpperCaseQuotedIdentifiers = metadata.runCatching { storesUpperCaseQuotedIdentifiers() }.orFalse()
+            storesLowerCaseQuotedIdentifiers = metadata.runCatching { storesLowerCaseQuotedIdentifiers() }.orFalse()
+            maxColumnNameLength = metadata.runCatching { maxColumnNameLength }.getOrDefault(0)
+        }
+
+        if (logger.isInfoEnabled()) {
+            val msg = "Connected to %s, productName: %s, productVersion: %s, logger: %s, dialect: %s"
+            logger.info(msg.format(url, productName, productVersion, logger, dialect))
+        }
+    }
+
+    /**
+     * Format the specific [SqlExpression] to an executable SQL string with execution arguments.
+     *
+     * @param expression the expression to be formatted.
+     * @param beautifySql output beautiful SQL strings with line-wrapping and indentation, default to `false`.
+     * @param indentSize the indent size, default to 2.
+     * @return a [Pair] combines the SQL string and its execution arguments.
+     */
+    override fun formatExpression(
+        expression: SqlExpression,
+        beautifySql: Boolean,
+        indentSize: Int
+    ): Pair<String, List<ArgumentExpression<*>>> {
+        val formatter = dialect.createSqlFormatter(this, beautifySql, indentSize)
+        formatter.visit(expression)
+        return Pair(formatter.sql, formatter.parameters)
+    }
+
+    /**
+     * Format the given [expression] to a SQL string with its execution arguments, then create
+     * a [PreparedStatement] from the this database using the SQL string and execute the specific
+     * callback function with it. After the callback function completes, the statement will be
+     * closed automatically.
+     *
+     * @since 2.7
+     * @param expression the SQL expression to be executed.
+     * @param func the callback function.
+     * @return the result of the callback function.
+     */
+    @OptIn(ExperimentalContracts::class)
+    public inline fun <T> executeExpression(expression: SqlExpression, func: (PreparedStatement) -> T): T {
+        contract {
+            callsInPlace(func, InvocationKind.EXACTLY_ONCE)
+        }
+
+        val (sql, args) = formatExpression(expression)
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("SQL: $sql")
+            logger.debug("Parameters: " + args.map { "${it.value}(${it.sqlType.typeName})" })
+        }
+
+        useConnection { conn ->
+            conn.prepareStatement(sql).use { statement ->
+                statement.setArguments(args)
+                return func(statement)
+            }
+        }
+    }
+
+    /**
+     * Format the given [expression] to a SQL string with its execution arguments, then execute it via
+     * [PreparedStatement.executeQuery] and return the result [CachedRowSet].
+     *
+     * @since 2.7
+     * @param expression the SQL expression to be executed.
+     * @return the result [CachedRowSet].
+     */
+    override fun executeQuery(expression: SqlExpression): CachedRowSet {
+        executeExpression(expression) { statement ->
+            statement.executeQuery().use { rs ->
+                val rowSet = CachedRowSet(rs)
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Results: ${rowSet.size()}")
+                }
+
+                return rowSet
+            }
+        }
+    }
+
+    /**
+     * Format the given [expression] to a SQL string with its execution arguments, then execute it via
+     * [PreparedStatement.executeUpdate] and return the effected row count.
+     *
+     * @since 2.7
+     * @param expression the SQL expression to be executed.
+     * @return the effected row count.
+     */
+    override fun executeUpdate(expression: SqlExpression): Int {
+        executeExpression(expression) { statement ->
+            val effects = statement.executeUpdate()
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Effects: $effects")
+            }
+
+            return effects
+        }
+    }
+
+    /**
+     * Format the given [expression] to a SQL string with its execution arguments, execute it via
+     * [PreparedStatement.executeUpdate], then return the effected row count along with the generated keys.
+     *
+     * @since 2.7
+     * @param expression the SQL expression to be executed.
+     * @return a [Pair] combines the effected row count and the generated keys.
+     */
+    override fun executeUpdateAndRetrieveKeys(expression: SqlExpression): Pair<Int, CachedRowSet> {
+        val (sql, args) = formatExpression(expression)
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("SQL: $sql")
+            logger.debug("Parameters: " + args.map { "${it.value}(${it.sqlType.typeName})" })
+        }
+
+        val (effects, rowSet) = dialect.executeUpdateAndRetrieveKeys(this, sql, args)
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Effects: $effects")
+        }
+
+        return Pair(effects, rowSet)
+    }
+
+    /**
+     * Batch execute the given SQL expressions and return the effected row counts for each expression.
+     *
+     * Note that this function is implemented based on [Statement.addBatch] and [Statement.executeBatch],
+     * and any item in a batch operation must have the same structure, otherwise an exception will be thrown.
+     *
+     * @since 2.7
+     * @param expressions the SQL expressions to be executed.
+     * @return the effected row counts for each sub-operation.
+     */
+    override fun executeBatch(expressions: List<SqlExpression>): IntArray {
+        val (sql, _) = formatExpression(expressions[0])
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("SQL: $sql")
+        }
+
+        useConnection { conn ->
+            conn.prepareStatement(sql).use { statement ->
+                for (expr in expressions) {
+                    val (subSql, args) = formatExpression(expr)
+
+                    if (subSql != sql) {
+                        throw IllegalArgumentException(
+                            "Every item in a batch operation must generate the same SQL: \n\n$subSql"
+                        )
+                    }
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Parameters: " + args.map { "${it.value}(${it.sqlType.typeName})" })
+                    }
+
+                    statement.setArguments(args)
+                    statement.addBatch()
+                }
+
+                val effects = statement.executeBatch()
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Effects: ${effects?.contentToString()}")
+                }
+
+                return effects
+            }
+        }
+    }
+}

--- a/ktorm-core/src/test/kotlin/org/ktorm/BaseTest.kt
+++ b/ktorm-core/src/test/kotlin/org/ktorm/BaseTest.kt
@@ -4,6 +4,7 @@ import org.junit.After
 import org.junit.Before
 import org.ktorm.database.Database
 import org.ktorm.database.use
+import org.ktorm.database.useConnection
 import org.ktorm.entity.Entity
 import org.ktorm.entity.sequenceOf
 import org.ktorm.logging.ConsoleLogger

--- a/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
+++ b/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
@@ -2,6 +2,7 @@ package org.ktorm.dsl
 
 import org.junit.Test
 import org.ktorm.BaseTest
+import org.ktorm.database.useTransaction
 import org.ktorm.entity.filter
 import org.ktorm.entity.first
 import org.ktorm.entity.forUpdate

--- a/ktorm-global/src/main/kotlin/org/ktorm/global/Global.kt
+++ b/ktorm-global/src/main/kotlin/org/ktorm/global/Global.kt
@@ -71,7 +71,7 @@ public fun Database.Companion.connectGlobally(
     generateSqlInUpperCase: Boolean? = null,
     connector: () -> Connection
 ): Database {
-    val database = Database(
+    val database = DatabaseImpl(
         transactionManager = JdbcTransactionManager(connector),
         dialect = dialect,
         logger = logger,
@@ -100,7 +100,7 @@ public fun Database.Companion.connectGlobally(
     alwaysQuoteIdentifiers: Boolean = false,
     generateSqlInUpperCase: Boolean? = null
 ): Database {
-    val database = Database(
+    val database = org.ktorm.database.DatabaseImpl(
         transactionManager = JdbcTransactionManager { dataSource.connection },
         dialect = dialect,
         logger = logger,
@@ -140,7 +140,7 @@ public fun Database.Companion.connectGlobally(
         Class.forName(driver)
     }
 
-    val database = Database(
+    val database = DatabaseImpl(
         transactionManager = JdbcTransactionManager { DriverManager.getConnection(url, user, password) },
         dialect = dialect,
         logger = logger,
@@ -179,7 +179,7 @@ public fun Database.Companion.connectWithSpringSupportGlobally(
 ): Database {
     val translator = SQLErrorCodeSQLExceptionTranslator(dataSource)
 
-    val database = Database(
+    val database = DatabaseImpl(
         transactionManager = SpringManagedTransactionManager(dataSource),
         dialect = dialect,
         logger = logger,

--- a/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/MySqlTest.kt
+++ b/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/MySqlTest.kt
@@ -7,6 +7,8 @@ import org.junit.Test
 import org.ktorm.BaseTest
 import org.ktorm.database.Database
 import org.ktorm.database.use
+import org.ktorm.database.useConnection
+import org.ktorm.database.useTransaction
 import org.ktorm.dsl.*
 import org.ktorm.entity.*
 import org.ktorm.jackson.json

--- a/ktorm-support-oracle/src/test/kotlin/org/ktorm/support/oracle/OracleTest.kt
+++ b/ktorm-support-oracle/src/test/kotlin/org/ktorm/support/oracle/OracleTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import org.ktorm.BaseTest
 import org.ktorm.database.Database
 import org.ktorm.database.use
+import org.ktorm.database.useConnection
 import org.ktorm.dsl.*
 import org.ktorm.entity.count
 import org.ktorm.entity.filter

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/PostgreSqlTest.kt
@@ -12,6 +12,8 @@ import org.junit.Test
 import org.ktorm.BaseTest
 import org.ktorm.database.Database
 import org.ktorm.database.use
+import org.ktorm.database.useConnection
+import org.ktorm.database.useTransaction
 import org.ktorm.dsl.*
 import org.ktorm.entity.*
 import org.ktorm.jackson.json

--- a/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/SQLiteTest.kt
+++ b/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/SQLiteTest.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.ktorm.BaseTest
 import org.ktorm.database.Database
 import org.ktorm.database.use
+import org.ktorm.database.useConnection
 import org.ktorm.dsl.*
 import org.ktorm.entity.count
 import org.ktorm.entity.find

--- a/ktorm-support-sqlserver/src/test/kotlin/org/ktorm/support/sqlserver/SqlServerTest.kt
+++ b/ktorm-support-sqlserver/src/test/kotlin/org/ktorm/support/sqlserver/SqlServerTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import org.ktorm.BaseTest
 import org.ktorm.database.Database
 import org.ktorm.database.use
+import org.ktorm.database.useConnection
 import org.ktorm.dsl.*
 import org.ktorm.entity.count
 import org.ktorm.entity.filter


### PR DESCRIPTION
Separates the `Database` class into a `Database` interface and `DatabaseImpl` implementing class.

This is almost backwards compatible: 
- `useConnection` and `useTransaction` had to be moved to extension functions because they are `inline` and have contracts, forcing consumers to add an `import`.
- Direct use of the constructor, `Database(...)`, has to change to `DatabaseImpl(...)`.

**Why make this change?**

It allows us to created uniquely typed `Database` implementations so our dependency injection system ([Koin](https://insert-koin.io)) can differentiate between the different databases we use:

```kotlin
class MySql(db: DatabaseImpl) : Database by db { }
class Snowflake(db: DatabaseImpl) : Database by db { }
```