### PR TITLE
Implement postgres extensions "cube" and "earthdistance"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,11 @@ subprojects { project ->
                             name = "Eric Fenderbosch"
                             email = "eric@fender.net"
                         }
+                        developer {
+                            id = "kocproz"
+                            name = "Kacper Stasiuk"
+                            email = "kocproz@pm.me"
+                        }
                     }
                 }
             }

--- a/ktorm-support-postgresql/ktorm-support-postgresql.gradle
+++ b/ktorm-support-postgresql/ktorm-support-postgresql.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     testImplementation project(path: ":ktorm-core", configuration: "testOutput")
     testImplementation project(":ktorm-jackson")
-    testImplementation "org.postgresql:postgresql:42.2.5"
+    implementation "org.postgresql:postgresql:42.2.5"
     testImplementation "org.testcontainers:postgresql:1.15.1"
     testImplementation "com.zaxxer:HikariCP:4.0.3"
     testImplementation "com.mchange:c3p0:0.9.5.5"

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/EarthDistance.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/EarthDistance.kt
@@ -1,0 +1,85 @@
+package org.ktorm.support.postgresql
+
+import org.ktorm.expression.ScalarExpression
+import org.ktorm.schema.BooleanSqlType
+import org.ktorm.schema.ColumnDeclaring
+import org.ktorm.schema.SqlType
+
+public enum class CubeExpressionType(private val value: String) {
+    /**
+     * Cube overlaps operator, translated to the && operator in PostgreSQL.
+     */
+    OVERLAP("&&"),
+
+    /**
+     * Cube contains operator, translated to the @> operator in PostgreSQL.
+     */
+    CONTAINS("@>"),
+
+    /**
+     * Cube contained in operator, translated to the <@ operator in PostgreSQL.
+     */
+    CONTAINED_IN("<@");
+
+    override fun toString(): String {
+        return value
+    }
+}
+
+/**
+ * Expression class represents PostgreSQL's `Cube` operations.
+ *
+ * @property type the expression's type.
+ * @property left the expression's left operand.
+ * @property right the expression's right operand.
+ */
+public data class CubeExpression<T : Any>(
+    val type: CubeExpressionType,
+    val left: ScalarExpression<Cube>,
+    val right: ScalarExpression<Cube>,
+    override val sqlType: SqlType<T>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : ScalarExpression<T>()
+
+/**
+ * Cube contains operator, translated to the @> operator in PostgreSQL.
+ */
+public infix fun ColumnDeclaring<Cube>.contains(argument: ColumnDeclaring<Cube>): CubeExpression<Boolean> {
+    return CubeExpression(CubeExpressionType.CONTAINS, asExpression(), argument.asExpression(), BooleanSqlType)
+}
+
+/**
+ * Cube contains operator, translated to the @> operator in PostgreSQL.
+ */
+public infix fun ColumnDeclaring<Cube>.contains(argument: Cube): CubeExpression<Boolean> {
+    return this.contains(wrapArgument(argument))
+}
+
+/**
+ * Cube contained in operator, translated to the <@ operator in PostgreSQL.
+ */
+public infix fun ColumnDeclaring<Cube>.containedIn(argument: ColumnDeclaring<Cube>): CubeExpression<Boolean> {
+    return CubeExpression(CubeExpressionType.CONTAINED_IN, asExpression(), argument.asExpression(), BooleanSqlType)
+}
+
+/**
+ * Cube contained in operator, translated to the <@ operator in PostgreSQL.
+ */
+public infix fun ColumnDeclaring<Cube>.containedIn(argument: Cube): CubeExpression<Boolean> {
+    return this.containedIn(wrapArgument(argument))
+}
+
+/**
+ * Cube overlap operator, translated to the && operator in PostgreSQL.
+ */
+public infix fun ColumnDeclaring<Cube>.overlaps(argument: ColumnDeclaring<Cube>): CubeExpression<Boolean> {
+    return CubeExpression(CubeExpressionType.OVERLAP, asExpression(), argument.asExpression(), BooleanSqlType)
+}
+
+/**
+ * Cube overlap operator, translated to the && operator in PostgreSQL.
+ */
+public infix fun ColumnDeclaring<Cube>.overlaps(argument: Cube): CubeExpression<Boolean> {
+    return this.overlaps(wrapArgument(argument))
+}

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/EarthDistance.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/EarthDistance.kt
@@ -1,8 +1,11 @@
 package org.ktorm.support.postgresql
 
+import org.ktorm.expression.ArgumentExpression
+import org.ktorm.expression.FunctionExpression
 import org.ktorm.expression.ScalarExpression
 import org.ktorm.schema.BooleanSqlType
 import org.ktorm.schema.ColumnDeclaring
+import org.ktorm.schema.DoubleSqlType
 import org.ktorm.schema.SqlType
 
 public enum class CubeExpressionType(private val value: String) {
@@ -35,8 +38,8 @@ public enum class CubeExpressionType(private val value: String) {
  */
 public data class CubeExpression<T : Any>(
     val type: CubeExpressionType,
-    val left: ScalarExpression<Cube>,
-    val right: ScalarExpression<Cube>,
+    val left: ScalarExpression<*>,
+    val right: ScalarExpression<*>,
     override val sqlType: SqlType<T>,
     override val isLeafNode: Boolean = false,
     override val extraProperties: Map<String, Any> = emptyMap()
@@ -57,6 +60,22 @@ public infix fun ColumnDeclaring<Cube>.contains(argument: Cube): CubeExpression<
 }
 
 /**
+ * Cube contains operator, translated to the @> operator in PostgreSQL.
+ */
+@JvmName("containsEarth")
+public infix fun ColumnDeclaring<Cube>.contains(argument: ColumnDeclaring<Earth>): CubeExpression<Boolean> {
+    return CubeExpression(CubeExpressionType.CONTAINS, asExpression(), argument.asExpression(), BooleanSqlType)
+}
+
+/**
+ * Cube contains operator, translated to the @> operator in PostgreSQL.
+ */
+@JvmName("containsEarth")
+public infix fun ColumnDeclaring<Cube>.contains(argument: Earth): CubeExpression<Boolean> {
+    return this.contains(ArgumentExpression(argument, PGEarthType))
+}
+
+/**
  * Cube contained in operator, translated to the <@ operator in PostgreSQL.
  */
 public infix fun ColumnDeclaring<Cube>.containedIn(argument: ColumnDeclaring<Cube>): CubeExpression<Boolean> {
@@ -68,6 +87,22 @@ public infix fun ColumnDeclaring<Cube>.containedIn(argument: ColumnDeclaring<Cub
  */
 public infix fun ColumnDeclaring<Cube>.containedIn(argument: Cube): CubeExpression<Boolean> {
     return this.containedIn(wrapArgument(argument))
+}
+
+/**
+ * Cube contained in operator, translated to the <@ operator in PostgreSQL.
+ */
+@JvmName("earthContainedInCube")
+public infix fun ColumnDeclaring<Earth>.containedIn(argument: ColumnDeclaring<Cube>): CubeExpression<Boolean> {
+    return CubeExpression(CubeExpressionType.CONTAINED_IN, asExpression(), argument.asExpression(), BooleanSqlType)
+}
+
+/**
+ * Cube contained in operator, translated to the <@ operator in PostgreSQL.
+ */
+@JvmName("earthContainedInCube")
+public infix fun ColumnDeclaring<Earth>.containedIn(argument: Cube): CubeExpression<Boolean> {
+    return this.containedIn(ArgumentExpression(argument, PGCubeType))
 }
 
 /**
@@ -83,3 +118,133 @@ public infix fun ColumnDeclaring<Cube>.overlaps(argument: ColumnDeclaring<Cube>)
 public infix fun ColumnDeclaring<Cube>.overlaps(argument: Cube): CubeExpression<Boolean> {
     return this.overlaps(wrapArgument(argument))
 }
+
+/**
+ * Returns the location of a point on the surface of the Earth
+ * given its latitude (argument 1) and longitude (argument 2) in degrees.
+ *
+ * Function from earthdistance extension
+ */
+public fun llToEarth(
+    lat: ColumnDeclaring<Double>,
+    lng: ColumnDeclaring<Double>
+): FunctionExpression<Earth> =
+    FunctionExpression(
+        functionName = "ll_to_earth",
+        arguments = listOf(lat.asExpression(), lng.asExpression()),
+        sqlType = PGEarthType
+    )
+
+/**
+ * Returns the location of a point on the surface of the Earth
+ * given its latitude (argument 1) and longitude (argument 2) in degrees.
+ */
+public fun llToEarth(
+    lat: ColumnDeclaring<Double>,
+    lng: Double
+): FunctionExpression<Earth> =
+    llToEarth(lat, ArgumentExpression(lng, DoubleSqlType))
+
+/**
+ * Returns the location of a point on the surface of the Earth
+ * given its latitude (argument 1) and longitude (argument 2) in degrees.
+ */
+public fun llToEarth(
+    lat: Double,
+    lng: ColumnDeclaring<Double>
+): FunctionExpression<Earth> =
+    llToEarth(ArgumentExpression(lat, DoubleSqlType), lng)
+
+/**
+ * Returns the location of a point on the surface of the Earth
+ * given its latitude (argument 1) and longitude (argument 2) in degrees.
+ */
+public fun llToEarth(
+    lat: Double,
+    lng: Double
+): FunctionExpression<Earth> =
+    llToEarth(ArgumentExpression(lat, DoubleSqlType), ArgumentExpression(lng, DoubleSqlType))
+
+/**
+ * Get distance between 2 points on earth.
+ *
+ * Function from earthdistance extension, `earth_distance(point1, point2)` in SQL.
+ */
+public fun earthDistance(
+    point1: ColumnDeclaring<Earth>,
+    point2: ColumnDeclaring<Earth>
+): FunctionExpression<Double> =
+    FunctionExpression(
+        functionName = "earth_distance",
+        arguments = listOf(point1.asExpression(), point2.asExpression()),
+        sqlType = DoubleSqlType
+    )
+
+/**
+ * Get distance between 2 points on earth.
+**/
+public fun earthDistance(
+    point1: ColumnDeclaring<Earth>,
+    point2: Earth
+): FunctionExpression<Double> =
+    earthDistance(point1, ArgumentExpression(point2, PGEarthType))
+
+/**
+ * Get distance between 2 points on earth.
+ **/
+public fun earthDistance(
+    point1: Earth,
+    point2: ColumnDeclaring<Earth>
+): FunctionExpression<Double> =
+    earthDistance(ArgumentExpression(point1, PGEarthType), point2)
+
+/**
+ * Get distance between 2 points on earth.
+ **/
+public fun earthDistance(
+    point1: Earth,
+    point2: Earth
+): FunctionExpression<Double> =
+    earthDistance(ArgumentExpression(point1, PGEarthType), ArgumentExpression(point2, PGEarthType))
+
+/**
+ * Creates a bounding cube, sized to contain all the points that are not farther than radius meters from a given point.
+ *
+ * Function from earthdistance extension, `earth_box(point, radius)` in SQL.
+ */
+public fun earthBox(
+    point: ColumnDeclaring<Earth>,
+    radius: ColumnDeclaring<Double>
+): FunctionExpression<Cube> =
+    FunctionExpression(
+        functionName = "earth_box",
+        arguments = listOf(point.asExpression(), radius.asExpression()),
+        sqlType = PGCubeType
+    )
+
+/**
+ * Creates a bounding cube, sized to contain all the points that are not farther than radius meters from a given point.
+**/
+public fun earthBox(
+    point: ColumnDeclaring<Earth>,
+    radius: Double
+): FunctionExpression<Cube> =
+    earthBox(point, ArgumentExpression(radius, DoubleSqlType))
+
+/**
+ * Creates a bounding cube, sized to contain all the points that are not farther than radius meters from a given point.
+ **/
+public fun earthBox(
+    point: Earth,
+    radius: ColumnDeclaring<Double>
+): FunctionExpression<Cube> =
+    earthBox(ArgumentExpression(point, PGEarthType), radius)
+
+/**
+ * Creates a bounding cube, sized to contain all the points that are not farther than radius meters from a given point.
+ **/
+public fun earthBox(
+    point: Earth,
+    radius: Double
+): FunctionExpression<Cube> =
+    earthBox(ArgumentExpression(point, PGEarthType), ArgumentExpression(radius, DoubleSqlType))

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -18,7 +18,15 @@ package org.ktorm.support.postgresql
 
 import org.ktorm.database.Database
 import org.ktorm.database.SqlDialect
-import org.ktorm.expression.*
+import org.ktorm.expression.ArgumentExpression
+import org.ktorm.expression.ColumnAssignmentExpression
+import org.ktorm.expression.QueryExpression
+import org.ktorm.expression.ScalarExpression
+import org.ktorm.expression.SelectExpression
+import org.ktorm.expression.SqlExpression
+import org.ktorm.expression.SqlExpressionVisitor
+import org.ktorm.expression.SqlFormatter
+import org.ktorm.expression.TableExpression
 import org.ktorm.schema.IntSqlType
 
 /**
@@ -60,6 +68,7 @@ public open class PostgreSqlFormatter(
         val result = when (expr) {
             is ILikeExpression -> visitILike(expr)
             is HStoreExpression -> visitHStore(expr)
+            is CubeExpression -> visitCube(expr)
             else -> super.visitScalar(expr)
         }
 
@@ -185,6 +194,30 @@ public open class PostgreSqlFormatter(
         return expr
     }
 
+    protected open fun <T : Any> visitCube(expr: CubeExpression<T>): CubeExpression<T> {
+        if (expr.left.removeBrackets) {
+            visit(expr.left)
+        } else {
+            write("(")
+            visit(expr.left)
+            removeLastBlank()
+            write(") ")
+        }
+
+        writeKeyword("${expr.type} ")
+
+        if (expr.right.removeBrackets) {
+            visit(expr.right)
+        } else {
+            write("(")
+            visit(expr.right)
+            removeLastBlank()
+            write(") ")
+        }
+
+        return expr
+    }
+
     protected open fun visitInsertOrUpdate(expr: InsertOrUpdateExpression): InsertOrUpdateExpression {
         writeKeyword("insert into ")
         visitTable(expr.table)
@@ -276,6 +309,7 @@ public open class PostgreSqlExpressionVisitor : SqlExpressionVisitor() {
         val result = when (expr) {
             is ILikeExpression -> visitILike(expr)
             is HStoreExpression -> visitHStore(expr)
+            is CubeExpression -> visitCube(expr)
             else -> super.visitScalar(expr)
         }
 
@@ -295,6 +329,17 @@ public open class PostgreSqlExpressionVisitor : SqlExpressionVisitor() {
     }
 
     protected open fun <T : Any> visitHStore(expr: HStoreExpression<T>): HStoreExpression<T> {
+        val left = visitScalar(expr.left)
+        val right = visitScalar(expr.right)
+
+        if (left === expr.left && right === expr.right) {
+            return expr
+        } else {
+            return expr.copy(left = left, right = right)
+        }
+    }
+
+    protected open fun <T : Any> visitCube(expr: CubeExpression<T>): CubeExpression<T> {
         val left = visitScalar(expr.left)
         val right = visitScalar(expr.right)
 

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/EarthdistanceTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/EarthdistanceTest.kt
@@ -12,6 +12,9 @@ import org.ktorm.dsl.insert
 import org.ktorm.dsl.map
 import org.ktorm.dsl.select
 import org.ktorm.dsl.where
+import org.ktorm.entity.Entity
+import org.ktorm.entity.add
+import org.ktorm.entity.sequenceOf
 import org.ktorm.logging.ConsoleLogger
 import org.ktorm.logging.LogLevel
 import org.ktorm.schema.Table
@@ -22,6 +25,17 @@ import org.testcontainers.containers.PostgreSQLContainer
  */
 class EarthdistanceTest : BaseTest() {
 
+    object TestTable : Table<TestRecord>("earthdistance_t") {
+        val e = earth("earth_field").bindTo { it.e }
+        val c = cube("cube_field").bindTo { it.c }
+    }
+
+    interface TestRecord : Entity<TestRecord> {
+        companion object : Entity.Factory<TestRecord>()
+        val e: Earth
+        var c: Cube
+    }
+    
     companion object {
         class KPostgreSqlContainer : PostgreSQLContainer<KPostgreSqlContainer>("postgres:13-alpine")
 
@@ -48,20 +62,16 @@ class EarthdistanceTest : BaseTest() {
 
     @Test
     fun testEarthType() {
-        val table = object : Table<Nothing>("earthdistance_t") {
-            val e = earth("earth_field")
-        }
-
         val earthValue = Earth(-849959.4557142439, -5441944.3654614175, 3216183.683045588)
-        val inserted = database.insert(table) {
-            set(table.e, earthValue)
+        val inserted = database.insert(TestTable) {
+            set(TestTable.e, earthValue)
         }
 
         val queried = database
-            .from(table)
+            .from(TestTable)
             .select()
-            .where(table.e eq earthValue)
-            .map { it[table.e] }
+            .where(TestTable.e eq earthValue)
+            .map { it[TestTable.e] }
             .firstOrNull()
 
         assertEquals(1, inserted)
@@ -70,27 +80,49 @@ class EarthdistanceTest : BaseTest() {
 
     @Test
     fun testCubeType() {
-        val table = object : Table<Nothing>("earthdistance_t") {
-            val c = cube("cube_field")
-        }
-
         assertThrows(IllegalArgumentException::class.java) {
             Cube(arrayOf(1.0), arrayOf(1.0, 2.0))
         }
 
         val cubeValue = Cube(arrayOf(-1.1, 2.2, 3.0), arrayOf(1.1, -2.2, 0.3))
-        val inserted = database.insert(table) {
-            set(table.c, cubeValue)
+        val inserted = database.insert(TestTable) {
+            set(TestTable.c, cubeValue)
         }
 
         val queried = database
-            .from(table)
+            .from(TestTable)
             .select()
-            .where(table.c eq cubeValue)
-            .map { it[table.c] }
+            .where(TestTable.c eq cubeValue)
+            .map { it[TestTable.c] }
             .firstOrNull()
 
         assertEquals(1, inserted)
         assertEquals(cubeValue, queried)
+    }
+
+    @Test
+    fun testCubeExpression() {
+        val cube1 = Cube(arrayOf(1.0, 1.0, 1.0), arrayOf(-1.0, -1.0, -1.0))
+        val cube2 = Cube(arrayOf(0.0, 0.0, 0.0), arrayOf(2.0, 2.0, 2.0))
+        val cube3 = Cube(arrayOf(0.5, 0.5, 0.5), arrayOf(-0.5, -0.5, -0.5))
+        val record = TestRecord()
+        record.c = cube1
+
+        database.sequenceOf(TestTable).add(record)
+
+        val t1 = (TestTable.c contains cube3).aliased("t1") // true
+        val t2 = (TestTable.c containedIn cube2).aliased("t2") // false
+        val t3 = (TestTable.c overlaps cube2).aliased("t3") // true
+        val t4 = (TestTable.c eq cube1).aliased("t4") // true
+        database.from(TestTable)
+            .select(
+                t1, t2, t3, t4
+            ).where(TestTable.c eq cube1)
+            .map { row ->
+                assertEquals(true, row[t1])
+                assertEquals(false, row[t2])
+                assertEquals(true, row[t3])
+                assertEquals(true, row[t4])
+            }
     }
 }

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/EarthdistanceTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/EarthdistanceTest.kt
@@ -1,7 +1,9 @@
 package org.ktorm.support.postgresql
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.ClassRule
 import org.junit.Test
 import org.ktorm.BaseTest
@@ -123,6 +125,41 @@ class EarthdistanceTest : BaseTest() {
                 assertEquals(false, row[t2])
                 assertEquals(true, row[t3])
                 assertEquals(true, row[t4])
+                return
             }
+        assertTrue(false) // Throws if above statement didn't return anything
+    }
+
+    @Test
+    fun testEarthDistanceFunctions() {
+        val distance = earthDistance(llToEarth(0.0, 0.0), llToEarth(1.0, 0.0)).aliased("distance")
+
+        val record = TestRecord()
+        record.c = Cube(arrayOf(0.0), arrayOf(0.0))
+        database.sequenceOf(TestTable).add(record)
+
+        database.from(TestTable)
+            .select(distance)
+            .map { row ->
+                assertTrue(row[distance]!! > 100000)
+            }
+
+        val box = earthBox(llToEarth(0.0, 0.0), 10000.0)
+        val pointInBox = llToEarth(0.01, 0.01)
+        val pointOutsideBox = llToEarth(10.0, 10.0)
+        val check1 = (box contains pointInBox).aliased("c1")
+        val check1r = (pointInBox containedIn box).aliased("c1r")
+        val check2 = (box contains pointOutsideBox).aliased("c2")
+        val check2r = (pointOutsideBox containedIn box).aliased("c2r")
+        database.from(TestTable)
+            .select(check1, check2, check1r, check2r)
+            .map { row ->
+                assertTrue(row[check1]!!)
+                assertTrue(row[check1r]!!)
+                assertFalse(row[check2]!!)
+                assertFalse(row[check2r]!!)
+                return
+            }
+        assertTrue(false)
     }
 }

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/EarthdistanceTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/EarthdistanceTest.kt
@@ -1,0 +1,96 @@
+package org.ktorm.support.postgresql
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.ClassRule
+import org.junit.Test
+import org.ktorm.BaseTest
+import org.ktorm.database.Database
+import org.ktorm.dsl.eq
+import org.ktorm.dsl.from
+import org.ktorm.dsl.insert
+import org.ktorm.dsl.map
+import org.ktorm.dsl.select
+import org.ktorm.dsl.where
+import org.ktorm.logging.ConsoleLogger
+import org.ktorm.logging.LogLevel
+import org.ktorm.schema.Table
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Created by Kacper on 14/01/2022
+ */
+class EarthdistanceTest : BaseTest() {
+
+    companion object {
+        class KPostgreSqlContainer : PostgreSQLContainer<KPostgreSqlContainer>("postgres:13-alpine")
+
+        @ClassRule
+        @JvmField
+        val postgres = KPostgreSqlContainer()
+    }
+
+    override fun init() {
+        database = Database.connect(
+            url = postgres.jdbcUrl,
+            driver = postgres.driverClassName,
+            user = postgres.username,
+            password = postgres.password,
+            logger = ConsoleLogger(threshold = LogLevel.TRACE)
+        )
+
+        execSqlScript("init-earthdistance.sql")
+    }
+
+    override fun destroy() {
+        execSqlScript("destroy-earthdistance.sql")
+    }
+
+    @Test
+    fun testEarthType() {
+        val table = object : Table<Nothing>("earthdistance_t") {
+            val e = earth("earth_field")
+        }
+
+        val earthValue = Earth(-849959.4557142439, -5441944.3654614175, 3216183.683045588)
+        val inserted = database.insert(table) {
+            set(table.e, earthValue)
+        }
+
+        val queried = database
+            .from(table)
+            .select()
+            .where(table.e eq earthValue)
+            .map { it[table.e] }
+            .firstOrNull()
+
+        assertEquals(1, inserted)
+        assertEquals(earthValue, queried)
+    }
+
+    @Test
+    fun testCubeType() {
+        val table = object : Table<Nothing>("earthdistance_t") {
+            val c = cube("cube_field")
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            Cube(arrayOf(1.0), arrayOf(1.0, 2.0))
+        }
+
+        val cubeValue = Cube(arrayOf(-1.1, 2.2, 3.0), arrayOf(1.1, -2.2, 0.3))
+        val inserted = database.insert(table) {
+            set(table.c, cubeValue)
+        }
+
+        val queried = database
+            .from(table)
+            .select()
+            .where(table.c eq cubeValue)
+            .map { it[table.c] }
+            .firstOrNull()
+
+        assertEquals(1, inserted)
+        assertEquals(cubeValue, queried)
+    }
+}

--- a/ktorm-support-postgresql/src/test/resources/destroy-earthdistance.sql
+++ b/ktorm-support-postgresql/src/test/resources/destroy-earthdistance.sql
@@ -1,0 +1,1 @@
+drop table earthdistance_t;

--- a/ktorm-support-postgresql/src/test/resources/init-earthdistance.sql
+++ b/ktorm-support-postgresql/src/test/resources/init-earthdistance.sql
@@ -1,0 +1,6 @@
+create extension if not exists earthdistance cascade;
+
+create table earthdistance_t(
+    earth_field         earth,
+    cube_field          cube
+);


### PR DESCRIPTION
I've implemented 2 data types (Earth, Cube) and some of the functions and operators from both extensions.

Extension docs:
- [cube](https://www.postgresql.org/docs/12/cube.html)
- [earthdistance](https://www.postgresql.org/docs/12/earthdistance.html)