### PR TITLE
Fix for issue #258 - insertOrUpdate for SQLite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,11 @@ subprojects { project ->
                             name = "Eric Fenderbosch"
                             email = "eric@fender.net"
                         }
+                        developer {
+                            id = "2938137849"
+                            name = "ccr"
+                            email = "2938137849@qq.com"
+                        }
                     }
                 }
             }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/BulkInsert.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/BulkInsert.kt
@@ -83,7 +83,6 @@ public data class BulkInsertExpression(
  * }
  * ```
  *
- * @since 3.3.0
  * @param table the table to be inserted.
  * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
  * @return the effected row count.
@@ -139,7 +138,6 @@ public fun <T : BaseTable<*>> Database.bulkInsert(
  * on conflict (id) do update set salary = t_employee.salary + ?
  * ```
  *
- * @since 3.3.0
  * @param table the table to be inserted.
  * @param block the DSL block used to construct the expression.
  * @return the effected row count.

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/BulkInsert.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/BulkInsert.kt
@@ -16,9 +16,7 @@
 
 package org.ktorm.support.sqlite
 
-import org.ktorm.database.CachedRowSet
 import org.ktorm.database.Database
-import org.ktorm.database.asIterable
 import org.ktorm.dsl.AssignmentsBuilder
 import org.ktorm.dsl.KtormDsl
 import org.ktorm.dsl.batchInsert
@@ -44,14 +42,12 @@ import org.ktorm.schema.Column
  * @property assignments column assignments of the bulk insert statement.
  * @property conflictColumns the index columns on which the conflict may happen.
  * @property updateAssignments the updated column assignments while key conflict exists.
- * @property returningColumns the returning columns.
  */
 public data class BulkInsertExpression(
     val table: TableExpression,
     val assignments: List<List<ColumnAssignmentExpression<*>>>,
     val conflictColumns: List<ColumnExpression<*>> = emptyList(),
     val updateAssignments: List<ColumnAssignmentExpression<*>> = emptyList(),
-    val returningColumns: List<ColumnExpression<*>> = emptyList(),
     override val isLeafNode: Boolean = false,
     override val extraProperties: Map<String, Any> = emptyMap()
 ) : SqlExpression()
@@ -98,171 +94,12 @@ public fun <T : BaseTable<*>> Database.bulkInsert(
     table: T, block: BulkInsertStatementBuilder<T>.(T) -> Unit
 ): Int {
     val builder = BulkInsertStatementBuilder(table).apply { block(table) }
-    val expression = BulkInsertExpression(table.asExpression(), builder.assignments)
-    return executeUpdate(expression)
-}
 
-/**
- * Bulk insert records to the table and return the specific column's values.
- *
- * Usage:
- *
- * ```kotlin
- * database.bulkInsertReturning(Employees, Employees.id) {
- *     item {
- *         set(it.name, "jerry")
- *         set(it.job, "trainee")
- *         set(it.managerId, 1)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.salary, 50)
- *         set(it.departmentId, 1)
- *     }
- *     item {
- *         set(it.name, "linda")
- *         set(it.job, "assistant")
- *         set(it.managerId, 3)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.salary, 100)
- *         set(it.departmentId, 2)
- *     }
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into table (name, job, manager_id, hire_date, salary, department_id)
- * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
- * returning id
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the column to return
- * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
- * @return the returning column's values.
- */
-public fun <T : BaseTable<*>, C : Any> Database.bulkInsertReturning(
-    table: T, returning: Column<C>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
-): List<C?> {
-    val rowSet = bulkInsertReturningRowSet(table, listOf(returning), block)
-    return rowSet.asIterable().map { row -> returning.sqlType.getResult(row, 1) }
-}
-
-/**
- * Bulk insert records to the table and return the specific columns' values.
- *
- * Usage:
- *
- * ```kotlin
- * database.bulkInsertReturning(Employees, Pair(Employees.id, Employees.job)) {
- *     item {
- *         set(it.name, "jerry")
- *         set(it.job, "trainee")
- *         set(it.managerId, 1)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.salary, 50)
- *         set(it.departmentId, 1)
- *     }
- *     item {
- *         set(it.name, "linda")
- *         set(it.job, "assistant")
- *         set(it.managerId, 3)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.salary, 100)
- *         set(it.departmentId, 2)
- *     }
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into table (name, job, manager_id, hire_date, salary, department_id)
- * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
- * returning id, job
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the columns to return
- * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
- * @return the returning columns' values.
- */
-public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.bulkInsertReturning(
-    table: T, returning: Pair<Column<C1>, Column<C2>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
-): List<Pair<C1?, C2?>> {
-    val (c1, c2) = returning
-    val rowSet = bulkInsertReturningRowSet(table, listOf(c1, c2), block)
-    return rowSet.asIterable().map { row -> Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2)) }
-}
-
-/**
- * Bulk insert records to the table and return the specific columns' values.
- *
- * Usage:
- *
- * ```kotlin
- * database.bulkInsertReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
- *     item {
- *         set(it.name, "jerry")
- *         set(it.job, "trainee")
- *         set(it.managerId, 1)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.salary, 50)
- *         set(it.departmentId, 1)
- *     }
- *     item {
- *         set(it.name, "linda")
- *         set(it.job, "assistant")
- *         set(it.managerId, 3)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.salary, 100)
- *         set(it.departmentId, 2)
- *     }
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into table (name, job, manager_id, hire_date, salary, department_id)
- * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
- * returning id, job, salary
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the columns to return
- * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
- * @return the returning columns' values.
- */
-public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.bulkInsertReturning(
-    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
-): List<Triple<C1?, C2?, C3?>> {
-    val (c1, c2, c3) = returning
-    val rowSet = bulkInsertReturningRowSet(table, listOf(c1, c2, c3), block)
-    return rowSet.asIterable().map { row ->
-        Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
-    }
-}
-
-/**
- * Bulk insert records to the table, returning row set.
- */
-private fun <T : BaseTable<*>> Database.bulkInsertReturningRowSet(
-    table: T, returning: List<Column<*>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
-): CachedRowSet {
-    val builder = BulkInsertStatementBuilder(table).apply { block(table) }
-
-    val expression = BulkInsertExpression(
-        table = table.asExpression(),
-        assignments = builder.assignments,
-        returningColumns = returning.map { it.asExpression() }
+    val expression = AliasRemover.visit(
+        BulkInsertExpression(table.asExpression(), builder.assignments)
     )
 
-    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
-    return rowSet
+    return executeUpdate(expression)
 }
 
 /**
@@ -311,180 +148,18 @@ private fun <T : BaseTable<*>> Database.bulkInsertReturningRowSet(
 public fun <T : BaseTable<*>> Database.bulkInsertOrUpdate(
     table: T, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
 ): Int {
-    val expression = buildBulkInsertOrUpdateExpression(table, returning = emptyList(), block = block)
+    val expression = AliasRemover.visit(
+        buildBulkInsertOrUpdateExpression(table, block = block)
+    )
+
     return executeUpdate(expression)
-}
-
-/**
- * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
- * automatically performs updates if any conflict exists, and finally returns the specific column.
- *
- * Usage:
- *
- * ```kotlin
- * database.bulkInsertOrUpdateReturning(Employees, Employees.id) {
- *     item {
- *         set(it.id, 1)
- *         set(it.name, "vince")
- *         set(it.job, "engineer")
- *         set(it.salary, 1000)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.departmentId, 1)
- *     }
- *     item {
- *         set(it.id, 5)
- *         set(it.name, "vince")
- *         set(it.job, "engineer")
- *         set(it.salary, 1000)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.departmentId, 1)
- *     }
- *     onConflict {
- *         set(it.salary, it.salary + 900)
- *     }
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into t_employee (id, name, job, salary, hire_date, department_id)
- * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
- * on conflict (id) do update set salary = t_employee.salary + ?
- * returning id
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the column to return
- * @param block the DSL block used to construct the expression.
- * @return the returning column's values.
- */
-public fun <T : BaseTable<*>, C : Any> Database.bulkInsertOrUpdateReturning(
-    table: T, returning: Column<C>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
-): List<C?> {
-    val expression = buildBulkInsertOrUpdateExpression(table, listOf(returning), block)
-    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
-    return rowSet.asIterable().map { row -> returning.sqlType.getResult(row, 1) }
-}
-
-/**
- * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
- * automatically performs updates if any conflict exists, and finally returns the specific columns.
- *
- * Usage:
- *
- * ```kotlin
- * database.bulkInsertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
- *     item {
- *         set(it.id, 1)
- *         set(it.name, "vince")
- *         set(it.job, "engineer")
- *         set(it.salary, 1000)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.departmentId, 1)
- *     }
- *     item {
- *         set(it.id, 5)
- *         set(it.name, "vince")
- *         set(it.job, "engineer")
- *         set(it.salary, 1000)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.departmentId, 1)
- *     }
- *     onConflict {
- *         set(it.salary, it.salary + 900)
- *     }
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into t_employee (id, name, job, salary, hire_date, department_id)
- * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
- * on conflict (id) do update set salary = t_employee.salary + ?
- * returning id, job
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the columns to return
- * @param block the DSL block used to construct the expression.
- * @return the returning columns' values.
- */
-public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.bulkInsertOrUpdateReturning(
-    table: T, returning: Pair<Column<C1>, Column<C2>>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
-): List<Pair<C1?, C2?>> {
-    val (c1, c2) = returning
-    val expression = buildBulkInsertOrUpdateExpression(table, listOf(c1, c2), block)
-    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
-    return rowSet.asIterable().map { row -> Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2)) }
-}
-
-/**
- * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
- * automatically performs updates if any conflict exists, and finally returns the specific columns.
- *
- * Usage:
- *
- * ```kotlin
- * database.bulkInsertOrUpdateReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
- *     item {
- *         set(it.id, 1)
- *         set(it.name, "vince")
- *         set(it.job, "engineer")
- *         set(it.salary, 1000)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.departmentId, 1)
- *     }
- *     item {
- *         set(it.id, 5)
- *         set(it.name, "vince")
- *         set(it.job, "engineer")
- *         set(it.salary, 1000)
- *         set(it.hireDate, LocalDate.now())
- *         set(it.departmentId, 1)
- *     }
- *     onConflict {
- *         set(it.salary, it.salary + 900)
- *     }
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into t_employee (id, name, job, salary, hire_date, department_id)
- * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
- * on conflict (id) do update set salary = t_employee.salary + ?
- * returning id, job, salary
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the columns to return
- * @param block the DSL block used to construct the expression.
- * @return the returning columns' values.
- */
-public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.bulkInsertOrUpdateReturning(
-    table: T,
-    returning: Triple<Column<C1>, Column<C2>, Column<C3>>,
-    block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
-): List<Triple<C1?, C2?, C3?>> {
-    val (c1, c2, c3) = returning
-    val expression = buildBulkInsertOrUpdateExpression(table, listOf(c1, c2, c3), block)
-    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
-    return rowSet.asIterable().map { row ->
-        Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
-    }
 }
 
 /**
  * Build a bulk insert or update expression.
  */
 private fun <T : BaseTable<*>> buildBulkInsertOrUpdateExpression(
-    table: T, returning: List<Column<*>>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+    table: T, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
 ): BulkInsertExpression {
     val builder = BulkInsertOrUpdateStatementBuilder(table).apply { block(table) }
 
@@ -507,8 +182,7 @@ private fun <T : BaseTable<*>> buildBulkInsertOrUpdateExpression(
         table = table.asExpression(),
         assignments = builder.assignments,
         conflictColumns = conflictColumns.map { it.asExpression() },
-        updateAssignments = if (builder.doNothing) emptyList() else builder.updateAssignments,
-        returningColumns = returning.map { it.asExpression() }
+        updateAssignments = if (builder.doNothing) emptyList() else builder.updateAssignments
     )
 }
 

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/BulkInsert.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/BulkInsert.kt
@@ -1,0 +1,556 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.support.sqlite
+
+import org.ktorm.database.CachedRowSet
+import org.ktorm.database.Database
+import org.ktorm.database.asIterable
+import org.ktorm.dsl.AssignmentsBuilder
+import org.ktorm.dsl.KtormDsl
+import org.ktorm.dsl.batchInsert
+import org.ktorm.expression.ColumnAssignmentExpression
+import org.ktorm.expression.ColumnExpression
+import org.ktorm.expression.SqlExpression
+import org.ktorm.expression.TableExpression
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+
+/**
+ * Bulk insert expression, represents a bulk insert statement in SQLite.
+ *
+ * For example:
+ *
+ * ```sql
+ * insert into table (column1, column2)
+ * values (?, ?), (?, ?), (?, ?)...
+ * on conflict (...) do update set ...`
+ * ```
+ *
+ * @property table the table to be inserted.
+ * @property assignments column assignments of the bulk insert statement.
+ * @property conflictColumns the index columns on which the conflict may happen.
+ * @property updateAssignments the updated column assignments while key conflict exists.
+ * @property returningColumns the returning columns.
+ */
+public data class BulkInsertExpression(
+    val table: TableExpression,
+    val assignments: List<List<ColumnAssignmentExpression<*>>>,
+    val conflictColumns: List<ColumnExpression<*>> = emptyList(),
+    val updateAssignments: List<ColumnAssignmentExpression<*>> = emptyList(),
+    val returningColumns: List<ColumnExpression<*>> = emptyList(),
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+/**
+ * Bulk insert records to the table and return the effected row count.
+ *
+ * The usage is almost the same as [batchInsert], but this function is implemented by generating a special SQL
+ * using SQLite's bulk insert syntax, instead of based on JDBC batch operations. For this reason, its performance
+ * is much better than [batchInsert].
+ *
+ * The generated SQL is like: `insert into table (column1, column2) values (?, ?), (?, ?), (?, ?)...`.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsert(Employees) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * @since 3.3.0
+ * @param table the table to be inserted.
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @return the effected row count.
+ * @see batchInsert
+ */
+public fun <T : BaseTable<*>> Database.bulkInsert(
+    table: T, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): Int {
+    val builder = BulkInsertStatementBuilder(table).apply { block(table) }
+    val expression = BulkInsertExpression(table.asExpression(), builder.assignments)
+    return executeUpdate(expression)
+}
+
+/**
+ * Bulk insert records to the table and return the specific column's values.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Employees.id) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into table (name, job, manager_id, hire_date, salary, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
+ * returning id
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the column to return
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @return the returning column's values.
+ */
+public fun <T : BaseTable<*>, C : Any> Database.bulkInsertReturning(
+    table: T, returning: Column<C>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<C?> {
+    val rowSet = bulkInsertReturningRowSet(table, listOf(returning), block)
+    return rowSet.asIterable().map { row -> returning.sqlType.getResult(row, 1) }
+}
+
+/**
+ * Bulk insert records to the table and return the specific columns' values.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into table (name, job, manager_id, hire_date, salary, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.bulkInsertReturning(
+    table: T, returning: Pair<Column<C1>, Column<C2>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<Pair<C1?, C2?>> {
+    val (c1, c2) = returning
+    val rowSet = bulkInsertReturningRowSet(table, listOf(c1, c2), block)
+    return rowSet.asIterable().map { row -> Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2)) }
+}
+
+/**
+ * Bulk insert records to the table and return the specific columns' values.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into table (name, job, manager_id, hire_date, salary, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.bulkInsertReturning(
+    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<Triple<C1?, C2?, C3?>> {
+    val (c1, c2, c3) = returning
+    val rowSet = bulkInsertReturningRowSet(table, listOf(c1, c2, c3), block)
+    return rowSet.asIterable().map { row ->
+        Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
+    }
+}
+
+/**
+ * Bulk insert records to the table, returning row set.
+ */
+private fun <T : BaseTable<*>> Database.bulkInsertReturningRowSet(
+    table: T, returning: List<Column<*>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): CachedRowSet {
+    val builder = BulkInsertStatementBuilder(table).apply { block(table) }
+
+    val expression = BulkInsertExpression(
+        table = table.asExpression(),
+        assignments = builder.assignments,
+        returningColumns = returning.map { it.asExpression() }
+    )
+
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+    return rowSet
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * and automatically performs updates if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdate(Employees) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * ```
+ *
+ * @since 3.3.0
+ * @param table the table to be inserted.
+ * @param block the DSL block used to construct the expression.
+ * @return the effected row count.
+ */
+public fun <T : BaseTable<*>> Database.bulkInsertOrUpdate(
+    table: T, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): Int {
+    val expression = buildBulkInsertOrUpdateExpression(table, returning = emptyList(), block = block)
+    return executeUpdate(expression)
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * automatically performs updates if any conflict exists, and finally returns the specific column.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Employees.id) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the column to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning column's values.
+ */
+public fun <T : BaseTable<*>, C : Any> Database.bulkInsertOrUpdateReturning(
+    table: T, returning: Column<C>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<C?> {
+    val expression = buildBulkInsertOrUpdateExpression(table, listOf(returning), block)
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+    return rowSet.asIterable().map { row -> returning.sqlType.getResult(row, 1) }
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * automatically performs updates if any conflict exists, and finally returns the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.bulkInsertOrUpdateReturning(
+    table: T, returning: Pair<Column<C1>, Column<C2>>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<Pair<C1?, C2?>> {
+    val (c1, c2) = returning
+    val expression = buildBulkInsertOrUpdateExpression(table, listOf(c1, c2), block)
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+    return rowSet.asIterable().map { row -> Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2)) }
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * automatically performs updates if any conflict exists, and finally returns the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.bulkInsertOrUpdateReturning(
+    table: T,
+    returning: Triple<Column<C1>, Column<C2>, Column<C3>>,
+    block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<Triple<C1?, C2?, C3?>> {
+    val (c1, c2, c3) = returning
+    val expression = buildBulkInsertOrUpdateExpression(table, listOf(c1, c2, c3), block)
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+    return rowSet.asIterable().map { row ->
+        Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
+    }
+}
+
+/**
+ * Build a bulk insert or update expression.
+ */
+private fun <T : BaseTable<*>> buildBulkInsertOrUpdateExpression(
+    table: T, returning: List<Column<*>>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): BulkInsertExpression {
+    val builder = BulkInsertOrUpdateStatementBuilder(table).apply { block(table) }
+
+    val conflictColumns = builder.conflictColumns.ifEmpty { table.primaryKeys }
+    if (conflictColumns.isEmpty()) {
+        val msg = "" +
+            "Table '$table' doesn't have a primary key, " +
+            "you must specify the conflict columns when calling onConflict(col) { .. }"
+        throw IllegalStateException(msg)
+    }
+
+    if (!builder.doNothing && builder.updateAssignments.isEmpty()) {
+        val msg = "" +
+            "Cannot leave the onConflict clause empty! " +
+            "If you desire no update action at all please explicitly call `doNothing()`"
+        throw IllegalStateException(msg)
+    }
+
+    return BulkInsertExpression(
+        table = table.asExpression(),
+        assignments = builder.assignments,
+        conflictColumns = conflictColumns.map { it.asExpression() },
+        updateAssignments = if (builder.doNothing) emptyList() else builder.updateAssignments,
+        returningColumns = returning.map { it.asExpression() }
+    )
+}
+
+/**
+ * DSL builder for bulk insert statements.
+ */
+@KtormDsl
+public open class BulkInsertStatementBuilder<T : BaseTable<*>>(internal val table: T) {
+    internal val assignments = ArrayList<List<ColumnAssignmentExpression<*>>>()
+
+    /**
+     * Add the assignments of a new row to the bulk insert.
+     */
+    public fun item(block: AssignmentsBuilder.() -> Unit) {
+        val builder = SQLiteAssignmentsBuilder().apply(block)
+
+        if (assignments.isEmpty()
+            || assignments[0].map { it.column.name } == builder.assignments.map { it.column.name }
+        ) {
+            assignments += builder.assignments
+        } else {
+            throw IllegalArgumentException("Every item in a batch operation must be the same.")
+        }
+    }
+}
+
+/**
+ * DSL builder for bulk insert or update statements.
+ */
+@KtormDsl
+public class BulkInsertOrUpdateStatementBuilder<T : BaseTable<*>>(table: T) : BulkInsertStatementBuilder<T>(table) {
+    internal val conflictColumns = ArrayList<Column<*>>()
+    internal val updateAssignments = ArrayList<ColumnAssignmentExpression<*>>()
+    internal var doNothing: Boolean = false
+
+    /**
+     * Specify the update assignments while any key conflict exists.
+     */
+    public fun onConflict(vararg columns: Column<*>, block: InsertOrUpdateOnConflictClauseBuilder.() -> Unit) {
+        val builder = InsertOrUpdateOnConflictClauseBuilder().apply(block)
+        this.conflictColumns += columns
+        this.updateAssignments += builder.assignments
+        this.doNothing = builder.doNothing
+    }
+}

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/Functions.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/Functions.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.support.sqlite
+
+import org.ktorm.expression.ArgumentExpression
+import org.ktorm.expression.FunctionExpression
+import org.ktorm.schema.*
+import java.math.BigDecimal
+import java.sql.Date
+import java.sql.Time
+import java.sql.Timestamp
+import java.time.*
+import java.util.*
+
+@PublishedApi
+internal inline fun <reified T : Any> sqlTypeOf(): SqlType<T>? {
+    val sqlType = when (T::class) {
+        Boolean::class -> BooleanSqlType
+        Int::class -> IntSqlType
+        Short::class -> ShortSqlType
+        Long::class -> LongSqlType
+        Float::class -> FloatSqlType
+        Double::class -> DoubleSqlType
+        BigDecimal::class -> DecimalSqlType
+        String::class -> VarcharSqlType
+        ByteArray::class -> BytesSqlType
+        Timestamp::class -> TimestampSqlType
+        Date::class -> DateSqlType
+        Time::class -> TimeSqlType
+        Instant::class -> InstantSqlType
+        LocalDateTime::class -> LocalDateTimeSqlType
+        LocalDate::class -> LocalDateSqlType
+        LocalTime::class -> LocalTimeSqlType
+        MonthDay::class -> MonthDaySqlType
+        YearMonth::class -> YearMonthSqlType
+        Year::class -> YearSqlType
+        UUID::class -> UuidSqlType
+        else -> null
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return sqlType as SqlType<T>?
+}
+
+// region SQLite: The JSON1 Extension
+
+/**
+ * SQLite json_extract function, translated to `json_extract(column, path)`.
+ */
+public inline fun <reified T : Any> ColumnDeclaring<*>.jsonExtract(
+    path: String,
+    sqlType: SqlType<T> = sqlTypeOf() ?: error("Cannot detect the result's SqlType, please specify manually.")
+): FunctionExpression<T> {
+    // json_extract(column, path)
+    return FunctionExpression(
+        functionName = "json_extract",
+        arguments = listOf(asExpression(), ArgumentExpression(path, VarcharSqlType)),
+        sqlType = sqlType
+    )
+}
+
+/**
+ * SQLite json_patch function, translated to `json_patch(left, right)`.
+ */
+public fun ColumnDeclaring<*>.jsonPatch(right: ColumnDeclaring<*>): FunctionExpression<String> {
+    // json_patch(left, right)
+    return FunctionExpression(
+        functionName = "json_patch",
+        arguments = listOf(this, right).map { it.asExpression() },
+        sqlType = VarcharSqlType
+    )
+}
+
+/**
+ * SQLite json_remove function, translated to `json_remove(column, path)`.
+ */
+public fun ColumnDeclaring<*>.jsonRemove(path: String): FunctionExpression<String> {
+    // json_remove(column, path)
+    return FunctionExpression(
+        functionName = "json_remove",
+        arguments = listOf(asExpression(), ArgumentExpression(path, VarcharSqlType)),
+        sqlType = VarcharSqlType
+    )
+}
+
+/**
+ * SQLite json_valid function, translated to `json_valid(column)`.
+ */
+public fun ColumnDeclaring<*>.jsonValid(): FunctionExpression<Boolean> {
+    // json_valid(column)
+    return FunctionExpression(
+        functionName = "json_valid",
+        arguments = listOf(asExpression()),
+        sqlType = BooleanSqlType
+    )
+}
+
+// endregion
+
+// region SQLite: Built-In Scalar SQL Functions
+
+/**
+ * SQLite random function, translated to `random()`.
+ */
+public fun random(): FunctionExpression<Long> {
+    return FunctionExpression(functionName = "random", arguments = emptyList(), sqlType = LongSqlType)
+}
+
+/**
+ * SQLite ifnull function, translated to `ifnull(left, right)`.
+ */
+public fun <T : Any> ColumnDeclaring<T>.ifNull(right: ColumnDeclaring<T>): FunctionExpression<T> {
+    // ifnull(left, right)
+    return FunctionExpression(
+        functionName = "ifnull",
+        arguments = listOf(this, right).map { it.asExpression() },
+        sqlType = sqlType
+    )
+}
+
+/**
+ * SQLite ifnull function, translated to `ifnull(left, right)`.
+ */
+public fun <T : Any> ColumnDeclaring<T>.ifNull(right: T?): FunctionExpression<T> {
+    return this.ifNull(wrapArgument(right))
+}
+
+/**
+ * SQLite iif function, translated to `iif(condition, then, otherwise)`.
+ */
+public fun <T : Any> iif(
+    condition: ColumnDeclaring<Boolean>,
+    then: ColumnDeclaring<T>,
+    otherwise: ColumnDeclaring<T>
+): FunctionExpression<T> {
+    // iif(condition, then, otherwise)
+    return FunctionExpression(
+        functionName = "iif",
+        arguments = listOf(condition, then, otherwise).map { it.asExpression() },
+        sqlType = then.sqlType
+    )
+}
+
+/**
+ * SQLite iif function, translated to `iif(condition, then, otherwise)`.
+ */
+public inline fun <reified T : Any> iif(
+    condition: ColumnDeclaring<Boolean>,
+    then: T,
+    otherwise: T,
+    sqlType: SqlType<T> = sqlTypeOf() ?: error("Cannot detect the param's SqlType, please specify manually.")
+): FunctionExpression<T> {
+    // iif(condition, then, otherwise)
+    return FunctionExpression(
+        functionName = "iif",
+        arguments = listOf(
+            condition.asExpression(),
+            ArgumentExpression(then, sqlType),
+            ArgumentExpression(otherwise, sqlType)
+        ),
+        sqlType = sqlType
+    )
+}
+
+/**
+ * SQLite instr function, translated to `instr(left, right)`.
+ */
+public fun ColumnDeclaring<String>.instr(right: ColumnDeclaring<String>): FunctionExpression<Int> {
+    // instr(left, right)
+    return FunctionExpression(
+        functionName = "instr",
+        arguments = listOf(this, right).map { it.asExpression() },
+        sqlType = IntSqlType
+    )
+}
+
+/**
+ * SQLite instr function, translated to `instr(left, right)`.
+ */
+public fun ColumnDeclaring<String>.instr(right: String): FunctionExpression<Int> {
+    return instr(wrapArgument(right))
+}
+
+/**
+ * SQLite replace function, translated to `replace(str, oldValue, newValue)`.
+ */
+public fun ColumnDeclaring<String>.replace(oldValue: String, newValue: String): FunctionExpression<String> {
+    // replace(str, oldValue, newValue)
+    return FunctionExpression(
+        functionName = "replace",
+        arguments = listOf(
+            this.asExpression(),
+            ArgumentExpression(oldValue, VarcharSqlType),
+            ArgumentExpression(newValue, VarcharSqlType)
+        ),
+        sqlType = VarcharSqlType
+    )
+}
+
+/**
+ * SQLite lower function, translated to `lower(str). `
+ */
+public fun ColumnDeclaring<String>.toLowerCase(): FunctionExpression<String> {
+    // lower(str)
+    return FunctionExpression(
+        functionName = "lower",
+        arguments = listOf(this.asExpression()),
+        sqlType = VarcharSqlType
+    )
+}
+
+/**
+ * SQLite upper function, translated to `upper(str). `
+ */
+public fun ColumnDeclaring<String>.toUpperCase(): FunctionExpression<String> {
+    // upper(str)
+    return FunctionExpression(
+        functionName = "upper",
+        arguments = listOf(this.asExpression()),
+        sqlType = VarcharSqlType
+    )
+}
+
+// endregion

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/Global.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/Global.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.support.sqlite
+
+import org.ktorm.database.Database
+import org.ktorm.dsl.batchInsert
+import org.ktorm.schema.BaseTable
+import java.lang.reflect.InvocationTargetException
+
+/**
+ * Obtain the global database instance via reflection, throwing an exception if ktorm-global is not
+ * available in the classpath.
+ */
+@Suppress("SwallowedException")
+internal val Database.Companion.global: Database get() {
+    try {
+        val cls = Class.forName("org.ktorm.global.GlobalKt")
+        val method = cls.getMethod("getGlobal", Database.Companion::class.java)
+        return method.invoke(null, Database.Companion) as Database
+    } catch (e: ClassNotFoundException) {
+        throw IllegalStateException("Cannot detect the global database object, please add ktorm-global to classpath", e)
+    } catch (e: InvocationTargetException) {
+        throw e.targetException
+    }
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, and automatically
+ * performs an update if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * Employees.insertOrUpdate {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id) values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = salary + ?
+ * ```
+ *
+ * @param block the DSL block used to construct the expression.
+ * @return the effected row count.
+ */
+public fun <T : BaseTable<*>> T.insertOrUpdate(block: InsertOrUpdateStatementBuilder.(T) -> Unit): Int {
+    return Database.global.insertOrUpdate(this, block)
+}
+
+/**
+ * Construct a bulk insert expression in the given closure, then execute it and return the effected row count.
+ *
+ * The usage is almost the same as [batchInsert], but this function is implemented by generating a special SQL
+ * using SQLite's bulk insert syntax, instead of based on JDBC batch operations. For this reason, its performance
+ * is much better than [batchInsert].
+ *
+ * The generated SQL is like: `insert into table (column1, column2) values (?, ?), (?, ?), (?, ?)...`.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * Employees.bulkInsert {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ * }
+ * ```
+ *
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @return the effected row count.
+ * @see batchInsert
+ */
+public fun <T : BaseTable<*>> T.bulkInsert(block: BulkInsertStatementBuilder<T>.(T) -> Unit): Int {
+    return Database.global.bulkInsert(this, block)
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * and automatically performs updates if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * Employees.bulkInsertOrUpdate {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = salary + ?
+ * ```
+ *
+ * @param block the DSL block used to construct the expression.
+ * @return the effected row count.
+ * @see bulkInsert
+ */
+public fun <T : BaseTable<*>> T.bulkInsertOrUpdate(block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit): Int {
+    return Database.global.bulkInsertOrUpdate(this, block)
+}

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
@@ -204,12 +204,4 @@ internal object AliasRemover : SQLiteExpressionVisitor() {
             return expr.copy(tableAlias = null)
         }
     }
-
-    override fun <T : Any> visitColumn(expr: ColumnExpression<T>): ColumnExpression<T> {
-        if (expr.table == null) {
-            return expr
-        } else {
-            return expr.copy(table = null)
-        }
-    }
 }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
@@ -16,7 +16,6 @@
 
 package org.ktorm.support.sqlite
 
-import org.ktorm.database.CachedRowSet
 import org.ktorm.database.Database
 import org.ktorm.dsl.AssignmentsBuilder
 import org.ktorm.dsl.KtormDsl
@@ -29,20 +28,18 @@ import org.ktorm.schema.Column
 
 /**
  * Insert or update expression, represents an insert statement with an
- * `on conflict (key) do update set` clause in PostgreSQL.
+ * `on conflict (key) do update set` clause in SQLite.
  *
  * @property table the table to be inserted.
  * @property assignments the inserted column assignments.
  * @property conflictColumns the index columns on which the conflict may happen.
  * @property updateAssignments the updated column assignments while any key conflict exists.
- * @property returningColumns the returning columns.
  */
 public data class InsertOrUpdateExpression(
     val table: TableExpression,
     val assignments: List<ColumnAssignmentExpression<*>>,
     val conflictColumns: List<ColumnExpression<*>> = emptyList(),
     val updateAssignments: List<ColumnAssignmentExpression<*>> = emptyList(),
-    val returningColumns: List<ColumnExpression<*>> = emptyList(),
     override val isLeafNode: Boolean = false,
     override val extraProperties: Map<String, Any> = emptyMap()
 ) : SqlExpression()
@@ -61,7 +58,7 @@ public data class InsertOrUpdateExpression(
  *     set(it.salary, 1000)
  *     set(it.hireDate, LocalDate.now())
  *     set(it.departmentId, 1)
- *     onConflict {
+ *     onConflict(it.id) {
  *         set(it.salary, it.salary + 900)
  *     }
  * }
@@ -83,133 +80,15 @@ public data class InsertOrUpdateExpression(
 public fun <T : BaseTable<*>> Database.insertOrUpdate(
     table: T, block: InsertOrUpdateStatementBuilder.(T) -> Unit
 ): Int {
-    val expression = buildInsertOrUpdateExpression(table, returning = emptyList(), block = block)
+    val expression = AliasRemover.visit(buildInsertOrUpdateExpression(table, block = block))
     return executeUpdate(expression)
-}
-
-/**
- * Insert a record to the table, determining if there is a key conflict while it's being inserted, automatically
- * performs an update if any conflict exists, and finally returns the specific columns.
- *
- * Usage:
- *
- * ```kotlin
- * val (id, job) = database.insertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
- *     set(it.id, 1)
- *     set(it.name, "vince")
- *     set(it.job, "engineer")
- *     set(it.salary, 1000)
- *     set(it.hireDate, LocalDate.now())
- *     set(it.departmentId, 1)
- *     onConflict {
- *         set(it.salary, it.salary + 900)
- *     }
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into t_employee (id, name, job, salary, hire_date, department_id)
- * values (?, ?, ?, ?, ?, ?)
- * on conflict (id) do update set salary = t_employee.salary + ?
- * returning id, job
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the columns to return
- * @param block the DSL block used to construct the expression.
- * @return the returning columns' values.
- */
-public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.insertOrUpdateReturning(
-    table: T, returning: Pair<Column<C1>, Column<C2>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
-): Pair<C1?, C2?> {
-    val (c1, c2) = returning
-    val row = insertOrUpdateReturningRow(table, listOf(c1, c2), block)
-    if (row == null) {
-        return Pair(null, null)
-    } else {
-        return Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2))
-    }
-}
-
-/**
- * Insert a record to the table, determining if there is a key conflict while it's being inserted, automatically
- * performs an update if any conflict exists, and finally returns the specific columns.
- *
- * Usage:
- *
- * ```kotlin
- * val (id, job, salary) =
- * database.insertOrUpdateReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
- *     set(it.id, 1)
- *     set(it.name, "vince")
- *     set(it.job, "engineer")
- *     set(it.salary, 1000)
- *     set(it.hireDate, LocalDate.now())
- *     set(it.departmentId, 1)
- *     onConflict {
- *         set(it.salary, it.salary + 900)
- *     }
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into t_employee (id, name, job, salary, hire_date, department_id)
- * values (?, ?, ?, ?, ?, ?)
- * on conflict (id) do update set salary = t_employee.salary + ?
- * returning id, job, salary
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the columns to return
- * @param block the DSL block used to construct the expression.
- * @return the returning columns' values.
- */
-public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.insertOrUpdateReturning(
-    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
-): Triple<C1?, C2?, C3?> {
-    val (c1, c2, c3) = returning
-    val row = insertOrUpdateReturningRow(table, listOf(c1, c2, c3), block)
-    if (row == null) {
-        return Triple(null, null, null)
-    } else {
-        return Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
-    }
-}
-
-/**
- * Insert or update, returning one row.
- */
-private fun <T : BaseTable<*>> Database.insertOrUpdateReturningRow(
-    table: T, returning: List<Column<*>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
-): CachedRowSet? {
-    val expression = buildInsertOrUpdateExpression(table, returning, block)
-    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
-
-    if (rowSet.size() == 0) {
-        // Possible when using onConflict { doNothing() }
-        return null
-    }
-
-    if (rowSet.size() == 1) {
-        check(rowSet.next())
-        return rowSet
-    } else {
-        val (sql, _) = formatExpression(expression, beautifySql = true)
-        throw IllegalStateException("Expected 1 row but ${rowSet.size()} returned from sql: \n\n$sql")
-    }
 }
 
 /**
  * Build an insert or update expression.
  */
 private fun <T : BaseTable<*>> buildInsertOrUpdateExpression(
-    table: T, returning: List<Column<*>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+    table: T, block: InsertOrUpdateStatementBuilder.(T) -> Unit
 ): InsertOrUpdateExpression {
     val builder = InsertOrUpdateStatementBuilder().apply { block(table) }
 
@@ -232,155 +111,15 @@ private fun <T : BaseTable<*>> buildInsertOrUpdateExpression(
         table = table.asExpression(),
         assignments = builder.assignments,
         conflictColumns = conflictColumns.map { it.asExpression() },
-        updateAssignments = if (builder.doNothing) emptyList() else builder.updateAssignments,
-        returningColumns = returning.map { it.asExpression() }
+        updateAssignments = if (builder.doNothing) emptyList() else builder.updateAssignments
     )
 }
 
 /**
- * Insert a record to the table and return the specific column.
- *
- * Usage:
- *
- * ```kotlin
- * val id = database.insertReturning(Employees, Employees.id) {
- *     set(it.id, 1)
- *     set(it.name, "vince")
- *     set(it.job, "engineer")
- *     set(it.salary, 1000)
- *     set(it.hireDate, LocalDate.now())
- *     set(it.departmentId, 1)
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into t_employee (id, name, job, salary, hire_date, department_id)
- * values (?, ?, ?, ?, ?, ?)
- * returning id
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the column to return
- * @param block the DSL block used to construct the expression.
- * @return the returning column's value.
- */
-public fun <T : BaseTable<*>, C : Any> Database.insertReturning(
-    table: T, returning: Column<C>, block: AssignmentsBuilder.(T) -> Unit
-): C? {
-    val row = insertReturningRow(table, listOf(returning), block)
-    return returning.sqlType.getResult(row, 1)
-}
-
-/**
- * Insert a record to the table and return the specific columns.
- *
- * Usage:
- *
- * ```kotlin
- * val (id, job) = database.insertReturning(Employees, Pair(Employees.id, Employees.job)) {
- *     set(it.id, 1)
- *     set(it.name, "vince")
- *     set(it.job, "engineer")
- *     set(it.salary, 1000)
- *     set(it.hireDate, LocalDate.now())
- *     set(it.departmentId, 1)
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into t_employee (id, name, job, salary, hire_date, department_id)
- * values (?, ?, ?, ?, ?, ?)
- * returning id, job
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the columns to return
- * @param block the DSL block used to construct the expression.
- * @return the returning columns' values.
- */
-public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.insertReturning(
-    table: T, returning: Pair<Column<C1>, Column<C2>>, block: AssignmentsBuilder.(T) -> Unit
-): Pair<C1?, C2?> {
-    val (c1, c2) = returning
-    val row = insertReturningRow(table, listOf(c1, c2), block)
-    return Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2))
-}
-
-/**
- * Insert a record to the table and return the specific columns.
- *
- * Usage:
- *
- * ```kotlin
- * val (id, job, salary) =
- * database.insertReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
- *     set(it.id, 1)
- *     set(it.name, "vince")
- *     set(it.job, "engineer")
- *     set(it.salary, 1000)
- *     set(it.hireDate, LocalDate.now())
- *     set(it.departmentId, 1)
- * }
- * ```
- *
- * Generated SQL:
- *
- * ```sql
- * insert into t_employee (id, name, job, salary, hire_date, department_id)
- * values (?, ?, ?, ?, ?, ?)
- * returning id, job, salary
- * ```
- *
- * @since 3.4.0
- * @param table the table to be inserted.
- * @param returning the columns to return
- * @param block the DSL block used to construct the expression.
- * @return the returning columns' values.
- */
-public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.insertReturning(
-    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: AssignmentsBuilder.(T) -> Unit
-): Triple<C1?, C2?, C3?> {
-    val (c1, c2, c3) = returning
-    val row = insertReturningRow(table, listOf(c1, c2, c3), block)
-    return Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
-}
-
-/**
- * Insert and returning one row.
- */
-private fun <T : BaseTable<*>> Database.insertReturningRow(
-    table: T, returning: List<Column<*>>, block: AssignmentsBuilder.(T) -> Unit
-): CachedRowSet {
-    val builder = PostgreSqlAssignmentsBuilder().apply { block(table) }
-
-    val expression = InsertOrUpdateExpression(
-        table = table.asExpression(),
-        assignments = builder.assignments,
-        returningColumns = returning.map { it.asExpression() }
-    )
-
-    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
-
-    if (rowSet.size() == 1) {
-        check(rowSet.next())
-        return rowSet
-    } else {
-        val (sql, _) = formatExpression(expression, beautifySql = true)
-        throw IllegalStateException("Expected 1 row but ${rowSet.size()} returned from sql: \n\n$sql")
-    }
-}
-
-/**
- * Base class of PostgreSQL DSL builders, provide basic functions used to build assignments for insert or update DSL.
+ * Base class of SQLite DSL builders, provide basic functions used to build assignments for insert or update DSL.
  */
 @KtormDsl
-public open class PostgreSqlAssignmentsBuilder : AssignmentsBuilder() {
+public open class SQLiteAssignmentsBuilder : AssignmentsBuilder() {
 
     /**
      * A getter that returns the readonly view of the built assignments list.
@@ -392,7 +131,7 @@ public open class PostgreSqlAssignmentsBuilder : AssignmentsBuilder() {
  * DSL builder for insert or update statements.
  */
 @KtormDsl
-public class InsertOrUpdateStatementBuilder : PostgreSqlAssignmentsBuilder() {
+public class InsertOrUpdateStatementBuilder : SQLiteAssignmentsBuilder() {
     internal val conflictColumns = ArrayList<Column<*>>()
     internal val updateAssignments = ArrayList<ColumnAssignmentExpression<*>>()
     internal var doNothing = false
@@ -423,7 +162,7 @@ public class InsertOrUpdateStatementBuilder : PostgreSqlAssignmentsBuilder() {
  * DSL builder for insert or update on conflict clause.
  */
 @KtormDsl
-public class InsertOrUpdateOnConflictClauseBuilder : PostgreSqlAssignmentsBuilder() {
+public class InsertOrUpdateOnConflictClauseBuilder : SQLiteAssignmentsBuilder() {
     internal var doNothing = false
 
     /**
@@ -443,5 +182,34 @@ public class InsertOrUpdateOnConflictClauseBuilder : PostgreSqlAssignmentsBuilde
             name = column.name,
             sqlType = column.sqlType
         )
+    }
+
+    /**
+     * be equal to 'set(column, excluded(column))'.
+     */
+    public fun <T : Any> setExcluded(column: Column<T>) {
+        set(column, excluded(column))
+    }
+}
+
+/**
+ * [SQLiteExpressionVisitor] implementation used to removed table aliases, used by Ktorm internal.
+ */
+internal object AliasRemover : SQLiteExpressionVisitor() {
+
+    override fun visitTable(expr: TableExpression): TableExpression {
+        if (expr.tableAlias == null) {
+            return expr
+        } else {
+            return expr.copy(tableAlias = null)
+        }
+    }
+
+    override fun <T : Any> visitColumn(expr: ColumnExpression<T>): ColumnExpression<T> {
+        if (expr.table == null) {
+            return expr
+        } else {
+            return expr.copy(table = null)
+        }
     }
 }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
@@ -167,6 +167,9 @@ public class InsertOrUpdateOnConflictClauseBuilder : SQLiteAssignmentsBuilder() 
     internal var where: ColumnDeclaring<Boolean>? = null
     internal var doNothing = false
 
+    /**
+     * Specify the where clause for this update statement.
+     */
     public fun where(block: () -> ColumnDeclaring<Boolean>) {
         this.where = block()
     }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
@@ -71,7 +71,6 @@ public data class InsertOrUpdateExpression(
  * on conflict (id) do update set salary = t_employee.salary + ?
  * ```
  *
- * @since 2.7
  * @param table the table to be inserted.
  * @param block the DSL block used to construct the expression.
  * @return the effected row count.

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
@@ -1,0 +1,447 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.support.sqlite
+
+import org.ktorm.database.CachedRowSet
+import org.ktorm.database.Database
+import org.ktorm.dsl.AssignmentsBuilder
+import org.ktorm.dsl.KtormDsl
+import org.ktorm.expression.ColumnAssignmentExpression
+import org.ktorm.expression.ColumnExpression
+import org.ktorm.expression.SqlExpression
+import org.ktorm.expression.TableExpression
+import org.ktorm.schema.BaseTable
+import org.ktorm.schema.Column
+
+/**
+ * Insert or update expression, represents an insert statement with an
+ * `on conflict (key) do update set` clause in PostgreSQL.
+ *
+ * @property table the table to be inserted.
+ * @property assignments the inserted column assignments.
+ * @property conflictColumns the index columns on which the conflict may happen.
+ * @property updateAssignments the updated column assignments while any key conflict exists.
+ * @property returningColumns the returning columns.
+ */
+public data class InsertOrUpdateExpression(
+    val table: TableExpression,
+    val assignments: List<ColumnAssignmentExpression<*>>,
+    val conflictColumns: List<ColumnExpression<*>> = emptyList(),
+    val updateAssignments: List<ColumnAssignmentExpression<*>> = emptyList(),
+    val returningColumns: List<ColumnExpression<*>> = emptyList(),
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : SqlExpression()
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, and automatically
+ * performs an update if any conflict exists.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.insertOrUpdate(Employees) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * ```
+ *
+ * @since 2.7
+ * @param table the table to be inserted.
+ * @param block the DSL block used to construct the expression.
+ * @return the effected row count.
+ */
+public fun <T : BaseTable<*>> Database.insertOrUpdate(
+    table: T, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): Int {
+    val expression = buildInsertOrUpdateExpression(table, returning = emptyList(), block = block)
+    return executeUpdate(expression)
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, automatically
+ * performs an update if any conflict exists, and finally returns the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val (id, job) = database.insertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.insertOrUpdateReturning(
+    table: T, returning: Pair<Column<C1>, Column<C2>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): Pair<C1?, C2?> {
+    val (c1, c2) = returning
+    val row = insertOrUpdateReturningRow(table, listOf(c1, c2), block)
+    if (row == null) {
+        return Pair(null, null)
+    } else {
+        return Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2))
+    }
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, automatically
+ * performs an update if any conflict exists, and finally returns the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val (id, job, salary) =
+ * database.insertOrUpdateReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.insertOrUpdateReturning(
+    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): Triple<C1?, C2?, C3?> {
+    val (c1, c2, c3) = returning
+    val row = insertOrUpdateReturningRow(table, listOf(c1, c2, c3), block)
+    if (row == null) {
+        return Triple(null, null, null)
+    } else {
+        return Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
+    }
+}
+
+/**
+ * Insert or update, returning one row.
+ */
+private fun <T : BaseTable<*>> Database.insertOrUpdateReturningRow(
+    table: T, returning: List<Column<*>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): CachedRowSet? {
+    val expression = buildInsertOrUpdateExpression(table, returning, block)
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+
+    if (rowSet.size() == 0) {
+        // Possible when using onConflict { doNothing() }
+        return null
+    }
+
+    if (rowSet.size() == 1) {
+        check(rowSet.next())
+        return rowSet
+    } else {
+        val (sql, _) = formatExpression(expression, beautifySql = true)
+        throw IllegalStateException("Expected 1 row but ${rowSet.size()} returned from sql: \n\n$sql")
+    }
+}
+
+/**
+ * Build an insert or update expression.
+ */
+private fun <T : BaseTable<*>> buildInsertOrUpdateExpression(
+    table: T, returning: List<Column<*>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): InsertOrUpdateExpression {
+    val builder = InsertOrUpdateStatementBuilder().apply { block(table) }
+
+    val conflictColumns = builder.conflictColumns.ifEmpty { table.primaryKeys }
+    if (conflictColumns.isEmpty()) {
+        val msg = "" +
+                "Table '$table' doesn't have a primary key, " +
+                "you must specify the conflict columns when calling onConflict(col) { .. }"
+        throw IllegalStateException(msg)
+    }
+
+    if (!builder.doNothing && builder.updateAssignments.isEmpty()) {
+        val msg = "" +
+                "Cannot leave the onConflict clause empty! " +
+                "If you desire no update action at all please explicitly call `doNothing()`"
+        throw IllegalStateException(msg)
+    }
+
+    return InsertOrUpdateExpression(
+        table = table.asExpression(),
+        assignments = builder.assignments,
+        conflictColumns = conflictColumns.map { it.asExpression() },
+        updateAssignments = if (builder.doNothing) emptyList() else builder.updateAssignments,
+        returningColumns = returning.map { it.asExpression() }
+    )
+}
+
+/**
+ * Insert a record to the table and return the specific column.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val id = database.insertReturning(Employees, Employees.id) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * returning id
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the column to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning column's value.
+ */
+public fun <T : BaseTable<*>, C : Any> Database.insertReturning(
+    table: T, returning: Column<C>, block: AssignmentsBuilder.(T) -> Unit
+): C? {
+    val row = insertReturningRow(table, listOf(returning), block)
+    return returning.sqlType.getResult(row, 1)
+}
+
+/**
+ * Insert a record to the table and return the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val (id, job) = database.insertReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.insertReturning(
+    table: T, returning: Pair<Column<C1>, Column<C2>>, block: AssignmentsBuilder.(T) -> Unit
+): Pair<C1?, C2?> {
+    val (c1, c2) = returning
+    val row = insertReturningRow(table, listOf(c1, c2), block)
+    return Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2))
+}
+
+/**
+ * Insert a record to the table and return the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val (id, job, salary) =
+ * database.insertReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.insertReturning(
+    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: AssignmentsBuilder.(T) -> Unit
+): Triple<C1?, C2?, C3?> {
+    val (c1, c2, c3) = returning
+    val row = insertReturningRow(table, listOf(c1, c2, c3), block)
+    return Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
+}
+
+/**
+ * Insert and returning one row.
+ */
+private fun <T : BaseTable<*>> Database.insertReturningRow(
+    table: T, returning: List<Column<*>>, block: AssignmentsBuilder.(T) -> Unit
+): CachedRowSet {
+    val builder = PostgreSqlAssignmentsBuilder().apply { block(table) }
+
+    val expression = InsertOrUpdateExpression(
+        table = table.asExpression(),
+        assignments = builder.assignments,
+        returningColumns = returning.map { it.asExpression() }
+    )
+
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+
+    if (rowSet.size() == 1) {
+        check(rowSet.next())
+        return rowSet
+    } else {
+        val (sql, _) = formatExpression(expression, beautifySql = true)
+        throw IllegalStateException("Expected 1 row but ${rowSet.size()} returned from sql: \n\n$sql")
+    }
+}
+
+/**
+ * Base class of PostgreSQL DSL builders, provide basic functions used to build assignments for insert or update DSL.
+ */
+@KtormDsl
+public open class PostgreSqlAssignmentsBuilder : AssignmentsBuilder() {
+
+    /**
+     * A getter that returns the readonly view of the built assignments list.
+     */
+    internal val assignments: List<ColumnAssignmentExpression<*>> get() = _assignments
+}
+
+/**
+ * DSL builder for insert or update statements.
+ */
+@KtormDsl
+public class InsertOrUpdateStatementBuilder : PostgreSqlAssignmentsBuilder() {
+    internal val conflictColumns = ArrayList<Column<*>>()
+    internal val updateAssignments = ArrayList<ColumnAssignmentExpression<*>>()
+    internal var doNothing = false
+
+    /**
+     * Specify the update assignments while any key conflict exists.
+     */
+    @Deprecated(
+        message = "This function will be removed in the future, please use onConflict { } instead",
+        replaceWith = ReplaceWith("onConflict(columns, block)")
+    )
+    public fun onDuplicateKey(vararg columns: Column<*>, block: AssignmentsBuilder.() -> Unit) {
+        onConflict(*columns, block = block)
+    }
+
+    /**
+     * Specify the update assignments while any key conflict exists.
+     */
+    public fun onConflict(vararg columns: Column<*>, block: InsertOrUpdateOnConflictClauseBuilder.() -> Unit) {
+        val builder = InsertOrUpdateOnConflictClauseBuilder().apply(block)
+        this.conflictColumns += columns
+        this.updateAssignments += builder.assignments
+        this.doNothing = builder.doNothing
+    }
+}
+
+/**
+ * DSL builder for insert or update on conflict clause.
+ */
+@KtormDsl
+public class InsertOrUpdateOnConflictClauseBuilder : PostgreSqlAssignmentsBuilder() {
+    internal var doNothing = false
+
+    /**
+     * Explicitly tells ktorm to ignore any on-conflict errors and continue insertion.
+     */
+    public fun doNothing() {
+        this.doNothing = true
+    }
+
+    /**
+     * Reference the 'EXCLUDED' table in a ON CONFLICT clause.
+     */
+    public fun <T : Any> excluded(column: Column<T>): ColumnExpression<T> {
+        // excluded.name
+        return ColumnExpression(
+            table = TableExpression(name = "excluded"),
+            name = column.name,
+            sqlType = column.sqlType
+        )
+    }
+}

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
@@ -95,15 +95,15 @@ private fun <T : BaseTable<*>> buildInsertOrUpdateExpression(
     val conflictColumns = builder.conflictColumns.ifEmpty { table.primaryKeys }
     if (conflictColumns.isEmpty()) {
         val msg = "" +
-                "Table '$table' doesn't have a primary key, " +
-                "you must specify the conflict columns when calling onConflict(col) { .. }"
+            "Table '$table' doesn't have a primary key, " +
+            "you must specify the conflict columns when calling onConflict(col) { .. }"
         throw IllegalStateException(msg)
     }
 
     if (!builder.doNothing && builder.updateAssignments.isEmpty()) {
         val msg = "" +
-                "Cannot leave the onConflict clause empty! " +
-                "If you desire no update action at all please explicitly call `doNothing()`"
+            "Cannot leave the onConflict clause empty! " +
+            "If you desire no update action at all please explicitly call `doNothing()`"
         throw IllegalStateException(msg)
     }
 

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
@@ -93,6 +93,11 @@ public open class SQLiteFormatter(
             if (expr.updateAssignments.isNotEmpty()) {
                 writeKeyword("do update set ")
                 visitColumnAssignments(expr.updateAssignments)
+
+                if (expr.where != null) {
+                    writeKeyword("where ")
+                    visit(expr.where)
+                }
             } else {
                 writeKeyword("do nothing ")
             }
@@ -122,6 +127,11 @@ public open class SQLiteFormatter(
             if (expr.updateAssignments.isNotEmpty()) {
                 writeKeyword("do update set ")
                 visitColumnAssignments(expr.updateAssignments)
+
+                if (expr.where != null) {
+                    writeKeyword("where ")
+                    visit(expr.where)
+                }
             } else {
                 writeKeyword("do nothing ")
             }
@@ -151,12 +161,14 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
         val assignments = visitColumnAssignments(expr.assignments)
         val conflictColumns = visitExpressionList(expr.conflictColumns)
         val updateAssignments = visitColumnAssignments(expr.updateAssignments)
+        val where = expr.where?.let { visitScalar(it) }
 
         @Suppress("ComplexCondition")
         if (table === expr.table
             && assignments === expr.assignments
             && conflictColumns === expr.conflictColumns
             && updateAssignments === expr.updateAssignments
+            && where === expr.where
         ) {
             return expr
         } else {
@@ -164,7 +176,8 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
                 table = table,
                 assignments = assignments,
                 conflictColumns = conflictColumns,
-                updateAssignments = updateAssignments
+                updateAssignments = updateAssignments,
+                where = where
             )
         }
     }
@@ -174,12 +187,14 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
         val assignments = visitBulkInsertAssignments(expr.assignments)
         val conflictColumns = visitExpressionList(expr.conflictColumns)
         val updateAssignments = visitColumnAssignments(expr.updateAssignments)
+        val where = expr.where?.let { visitScalar(it) }
 
         @Suppress("ComplexCondition")
         if (table === expr.table
             && assignments === expr.assignments
             && conflictColumns === expr.conflictColumns
             && updateAssignments === expr.updateAssignments
+            && where === expr.where
         ) {
             return expr
         } else {
@@ -187,7 +202,8 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
                 table = table,
                 assignments = assignments,
                 conflictColumns = conflictColumns,
-                updateAssignments = updateAssignments
+                updateAssignments = updateAssignments,
+                where = where
             )
         }
     }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
@@ -137,5 +137,4 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
             )
         }
     }
-
 }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
@@ -170,18 +170,16 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
     }
 
     protected open fun visitBulkInsert(expr: BulkInsertExpression): BulkInsertExpression {
-        val table = expr.table
+        val table = visitTable(expr.table)
         val assignments = visitBulkInsertAssignments(expr.assignments)
         val conflictColumns = visitExpressionList(expr.conflictColumns)
         val updateAssignments = visitColumnAssignments(expr.updateAssignments)
-        val returningColumns = visitExpressionList(expr.returningColumns)
 
         @Suppress("ComplexCondition")
         if (table === expr.table
             && assignments === expr.assignments
             && conflictColumns === expr.conflictColumns
             && updateAssignments === expr.updateAssignments
-            && returningColumns === expr.returningColumns
         ) {
             return expr
         } else {
@@ -189,8 +187,7 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
                 table = table,
                 assignments = assignments,
                 conflictColumns = conflictColumns,
-                updateAssignments = updateAssignments,
-                returningColumns = returningColumns
+                updateAssignments = updateAssignments
             )
         }
     }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
@@ -99,7 +99,6 @@ public open class SQLiteFormatter(
 
         return expr
     }
-
 }
 
 /**

--- a/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/SQLiteTest.kt
+++ b/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/SQLiteTest.kt
@@ -79,6 +79,35 @@ class SQLiteTest : BaseTest() {
     }
 
     @Test
+    fun testInsertOrUpdate() {
+        database.insertOrUpdate(Employees) {
+            set(it.id, 1)
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+            onConflict {
+                set(it.salary, it.salary + 1000)
+            }
+        }
+        database.insertOrUpdate(Employees.aliased("t")) {
+            set(it.id, 5)
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+            onConflict(it.id) {
+                set(it.salary, it.salary + 1000)
+            }
+        }
+
+        assert(database.employees.find { it.id eq 1 }!!.salary == 1100L)
+        assert(database.employees.find { it.id eq 5 }!!.salary == 1000L)
+    }
+
+    @Test
     fun testLimit() {
         val query = database.from(Employees).select().orderBy(Employees.id.desc()).limit(0, 2)
         assert(query.totalRecords == 4)


### PR DESCRIPTION
resolve #258 

> Since 3.24 SQLite supports [upsert like postgres does](https://www.sqlite.org/lang_UPSERT.html). Consider adding it to SQLite dialect?

- SQLite 方言: 添加 'insertOrUpdate' 支持 (InsertOrUpdate.kt)
- SQLite 方言: 添加 SQLite 特有的部分方法:  (Functions.kt)
  - jsonExtract, jsonPatch, jsonValid, random, ifNull, iif, instr, replace, toLowerCase, toUpperCase
- SQLite 方言: 添加 'bulkInsert' & 'bulkInsertOrUpdate' 支持 (BlukInsert.kt)
- SQLite 方言: 添加 冲突更新时 'where' 支持 (InsertOrUpdate.kt) & (BlukInsert.kt)
- SQLite 方言: 添加 'insertOrUpdate' & 'bulkInsert' & 'bulkInsertOrUpdate' 全局方法  (Global.kt)
- SQLite 方言: 添加 'insertOrUpdate' & 'bulkInsert' & 'bulkInsertOrUpdate' 的测试用例 (SQLiteTest.kt)