### PR TITLE
Make casting work

### DIFF
--- a/buildSrc/src/main/kotlin/ktorm.maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktorm.maven-publish.gradle.kts
@@ -131,6 +131,11 @@ publishing {
                         name.set("ccr")
                         email.set("2938137849@qq.com")
                     }
+                    developer {
+                        id.set("svenallers")
+                        name.set("Sven Allers")
+                        email.set("sven.allers@gmx.de")
+                    }
                 }
             }
         }

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -392,9 +392,9 @@ public abstract class SqlFormatter(
     }
 
     override fun <T : Any> visitCasting(expr: CastingExpression<T>): CastingExpression<T> {
-        write("CAST(")
+        writeKeyword("cast(")
         writeExpression(expr.expression)
-        write("AS ${expr.sqlType.typeName}) ")
+        writeKeyword("as ${expr.sqlType.typeName}) ")
         return expr
     }
 

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -73,6 +73,17 @@ public abstract class SqlFormatter(
         _builder.append(value)
     }
 
+    protected fun writeExpression(expr: SqlExpression) {
+        if (expr.removeBrackets) {
+            visit(expr)
+        } else {
+            write("(")
+            visit(expr)
+            removeLastBlank()
+            write(") ")
+        }
+    }
+
     protected fun writeKeyword(keyword: String) {
         when (database.generateSqlInUpperCase) {
             true -> {
@@ -210,53 +221,20 @@ public abstract class SqlFormatter(
 
     override fun <T : Any> visitUnary(expr: UnaryExpression<T>): UnaryExpression<T> {
         if (expr.type == UnaryExpressionType.IS_NULL || expr.type == UnaryExpressionType.IS_NOT_NULL) {
-            if (expr.operand.removeBrackets) {
-                visit(expr.operand)
-            } else {
-                write("(")
-                visit(expr.operand)
-                removeLastBlank()
-                write(") ")
-            }
-
+            writeExpression(expr.operand)
             writeKeyword("${expr.type} ")
         } else {
             writeKeyword("${expr.type} ")
-
-            if (expr.operand.removeBrackets) {
-                visit(expr.operand)
-            } else {
-                write("(")
-                visit(expr.operand)
-                removeLastBlank()
-                write(") ")
-            }
+            writeExpression(expr.operand)
         }
 
         return expr
     }
 
     override fun <T : Any> visitBinary(expr: BinaryExpression<T>): BinaryExpression<T> {
-        if (expr.left.removeBrackets) {
-            visit(expr.left)
-        } else {
-            write("(")
-            visit(expr.left)
-            removeLastBlank()
-            write(") ")
-        }
-
+        writeExpression(expr.left)
         writeKeyword("${expr.type} ")
-
-        if (expr.right.removeBrackets) {
-            visit(expr.right)
-        } else {
-            write("(")
-            visit(expr.right)
-            removeLastBlank()
-            write(") ")
-        }
-
+        writeExpression(expr.right)
         return expr
     }
 
@@ -314,13 +292,8 @@ public abstract class SqlFormatter(
         if (expr.declaredName != null && expr.declaredName.isNotBlank()) {
             checkColumnName(expr.declaredName)
             write("${expr.declaredName.quoted} ")
-        } else if (expr.expression.removeBrackets) {
-            visit(expr.expression)
         } else {
-            write("(")
-            visit(expr.expression)
-            removeLastBlank()
-            write(") ")
+            writeExpression(expr.expression)
         }
 
         return expr
@@ -415,6 +388,13 @@ public abstract class SqlFormatter(
             }
         }
 
+        return expr
+    }
+
+    override fun <T : Any> visitCasting(expr: CastingExpression<T>): CastingExpression<T> {
+        write("CAST(")
+        writeExpression(expr.expression)
+        write("AS ${expr.sqlType.typeName}) ")
         return expr
     }
 

--- a/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
+++ b/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
@@ -4,11 +4,10 @@ import org.junit.Test
 import org.ktorm.BaseTest
 import org.ktorm.database.use
 import org.ktorm.expression.ScalarExpression
-import org.ktorm.schema.IntSqlType
 import org.ktorm.schema.TextSqlType
 import java.sql.Clob
 import kotlin.random.Random
-import kotlin.test.assertEquals
+import kotlin.test.assertContentEquals
 
 /**
  * Created by vince on Dec 07, 2018.
@@ -207,6 +206,7 @@ class QueryTest : BaseTest() {
         assert(names.size == 3)
         println(names)
     }
+
     @Test
     fun testCast() {
         val salaries = database
@@ -220,7 +220,7 @@ class QueryTest : BaseTest() {
                 }
             }
 
-        assertEquals(listOf("200"), salaries)
+        assertContentEquals(listOf("200"), salaries)
     }
 
     @Test

--- a/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
+++ b/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
@@ -2,8 +2,13 @@ package org.ktorm.dsl
 
 import org.junit.Test
 import org.ktorm.BaseTest
+import org.ktorm.database.use
 import org.ktorm.expression.ScalarExpression
+import org.ktorm.schema.IntSqlType
+import org.ktorm.schema.TextSqlType
+import java.sql.Clob
 import kotlin.random.Random
+import kotlin.test.assertEquals
 
 /**
  * Created by vince on Dec 07, 2018.
@@ -201,6 +206,21 @@ class QueryTest : BaseTest() {
 
         assert(names.size == 3)
         println(names)
+    }
+    @Test
+    fun testCast() {
+        val salaries = database
+            .from(Employees)
+            .select(Employees.salary.cast(TextSqlType))
+            .where { Employees.salary eq 200 }
+            .map { row ->
+                when(val value = row.getObject(1)) {
+                    is Clob -> value.characterStream.use { it.readText() }
+                    else -> value
+                }
+            }
+
+        assertEquals(listOf("200"), salaries)
     }
 
     @Test

--- a/ktorm-global/src/test/kotlin/org/ktorm/global/GlobalQueryTest.kt
+++ b/ktorm-global/src/test/kotlin/org/ktorm/global/GlobalQueryTest.kt
@@ -2,8 +2,12 @@ package org.ktorm.global
 
 import org.junit.Test
 import org.ktorm.database.DialectFeatureNotSupportedException
+import org.ktorm.database.use
 import org.ktorm.dsl.*
 import org.ktorm.expression.ScalarExpression
+import org.ktorm.schema.TextSqlType
+import java.sql.Clob
+import kotlin.test.assertContentEquals
 
 /**
  * Created by vince at Apr 05, 2020.
@@ -193,6 +197,22 @@ class GlobalQueryTest : BaseGlobalTest() {
 
         assert(names.size == 3)
         println(names)
+    }
+
+    @Test
+    fun testCast() {
+        val salaries = database
+            .from(Employees)
+            .select(Employees.salary.cast(TextSqlType))
+            .where { Employees.salary eq 200 }
+            .map { row ->
+                when(val value = row.getObject(1)) {
+                    is Clob -> value.characterStream.use { it.readText() }
+                    else -> value
+                }
+            }
+
+        assertContentEquals(listOf("200"), salaries)
     }
 
     @Test

--- a/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/QueryTest.kt
+++ b/ktorm-support-mysql/src/test/kotlin/org/ktorm/support/mysql/QueryTest.kt
@@ -1,0 +1,20 @@
+package org.ktorm.support.mysql
+
+import org.junit.Test
+import org.ktorm.dsl.*
+import org.ktorm.schema.FloatSqlType
+import kotlin.test.assertContentEquals
+
+class QueryTest : BaseMySqlTest() {
+
+    @Test
+    fun testCast() {
+        val salaries = database
+            .from(Employees)
+            .select(Employees.salary.cast(FloatSqlType))
+            .where { Employees.salary eq 200 }
+            .map { it.getObject(1) }
+
+        assertContentEquals(listOf(200.0f), salaries)
+    }
+}

--- a/ktorm-support-oracle/src/test/kotlin/org/ktorm/support/oracle/CommonTest.kt
+++ b/ktorm-support-oracle/src/test/kotlin/org/ktorm/support/oracle/CommonTest.kt
@@ -120,7 +120,7 @@ class CommonTest : BaseOracleTest() {
         }
 
         assert(database.sequenceOf(t).filter { it.id eq 1 }.mapTo(HashSet()) { it.name } == setOf("test"))
-        assert(database.sequenceOf(t.aliased("t")).mapTo(HashSet()) { it.name } == setOf("test", "finance"))
+        assert(database.sequenceOf(t.aliased("t")).mapTo(HashSet()) { it.name } == setOf("test", "finance", "ai"))
     }
 
     @Test

--- a/ktorm-support-oracle/src/test/kotlin/org/ktorm/support/oracle/QueryTest.kt
+++ b/ktorm-support-oracle/src/test/kotlin/org/ktorm/support/oracle/QueryTest.kt
@@ -1,0 +1,21 @@
+package org.ktorm.support.oracle
+
+import org.junit.Test
+import org.ktorm.dsl.*
+import org.ktorm.schema.IntSqlType
+import java.math.BigDecimal
+import kotlin.test.assertContentEquals
+
+class QueryTest : BaseOracleTest() {
+
+    @Test
+    fun testCast() {
+        val mixedCases = database
+            .from(Departments)
+            .select(Departments.mixedCase.cast(IntSqlType))
+            .where { Departments.mixedCase eq "123" }
+            .map { it.getObject(1)}
+
+        assertContentEquals(listOf(BigDecimal(123)), mixedCases)
+    }
+}

--- a/ktorm-support-oracle/src/test/resources/init-oracle-data.sql
+++ b/ktorm-support-oracle/src/test/resources/init-oracle-data.sql
@@ -17,6 +17,7 @@ create table "t_employee"(
 
 insert into "t_department"("id", "name", "location") values (1, 'tech', 'Guangzhou');
 insert into "t_department"("id", "name", "location") values (2, 'finance', 'Beijing');
+insert into "t_department"("id", "name", "location", "mixedCase") values (3, 'ai', 'Hamburg', '123');
 
 insert into "t_employee"("id", "name", "job", "manager_id", "hire_date", "salary", "department_id")
     values (1, 'vince', 'engineer', null, to_date('2018-01-01', 'yyyy-MM-dd'), 100, 1);

--- a/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
+++ b/ktorm-support-postgresql/src/main/kotlin/org/ktorm/support/postgresql/PostgreSqlDialect.kt
@@ -147,74 +147,23 @@ public open class PostgreSqlFormatter(
     }
 
     protected open fun visitILike(expr: ILikeExpression): ILikeExpression {
-        if (expr.left.removeBrackets) {
-            visit(expr.left)
-        } else {
-            write("(")
-            visit(expr.left)
-            removeLastBlank()
-            write(") ")
-        }
-
+        writeExpression(expr.left)
         writeKeyword("ilike ")
-
-        if (expr.right.removeBrackets) {
-            visit(expr.right)
-        } else {
-            write("(")
-            visit(expr.right)
-            removeLastBlank()
-            write(") ")
-        }
-
+        writeExpression(expr.right)
         return expr
     }
 
     protected open fun <T : Any> visitHStore(expr: HStoreExpression<T>): HStoreExpression<T> {
-        if (expr.left.removeBrackets) {
-            visit(expr.left)
-        } else {
-            write("(")
-            visit(expr.left)
-            removeLastBlank()
-            write(") ")
-        }
-
+        writeExpression(expr.left)
         writeKeyword("${expr.type} ")
-
-        if (expr.right.removeBrackets) {
-            visit(expr.right)
-        } else {
-            write("(")
-            visit(expr.right)
-            removeLastBlank()
-            write(") ")
-        }
-
+        writeExpression(expr.right)
         return expr
     }
 
     protected open fun <T : Any> visitCube(expr: CubeExpression<T>): CubeExpression<T> {
-        if (expr.left.removeBrackets) {
-            visit(expr.left)
-        } else {
-            write("(")
-            visit(expr.left)
-            removeLastBlank()
-            write(") ")
-        }
-
+        writeExpression(expr.left)
         writeKeyword("${expr.type} ")
-
-        if (expr.right.removeBrackets) {
-            visit(expr.right)
-        } else {
-            write("(")
-            visit(expr.right)
-            removeLastBlank()
-            write(") ")
-        }
-
+        writeExpression(expr.right)
         return expr
     }
 

--- a/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/QueryTest.kt
+++ b/ktorm-support-postgresql/src/test/kotlin/org/ktorm/support/postgresql/QueryTest.kt
@@ -1,0 +1,27 @@
+package org.ktorm.support.postgresql
+
+import org.junit.Test
+import org.ktorm.database.use
+import org.ktorm.dsl.*
+import org.ktorm.schema.TextSqlType
+import java.sql.Clob
+import kotlin.test.assertEquals
+
+class QueryTest : BasePostgreSqlTest() {
+
+    @Test
+    fun testCast() {
+        val salaries = database
+            .from(Employees)
+            .select(Employees.salary.cast(TextSqlType))
+            .where { Employees.salary eq 200 }
+            .map { row ->
+                when(val value = row.getObject(1)) {
+                    is Clob -> value.characterStream.use { it.readText() }
+                    else -> value
+                }
+            }
+
+        assertEquals(listOf("200"), salaries)
+    }
+}

--- a/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/QueryTest.kt
+++ b/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/QueryTest.kt
@@ -1,0 +1,27 @@
+package org.ktorm.support.sqlite
+
+import org.junit.Test
+import org.ktorm.database.use
+import org.ktorm.dsl.*
+import org.ktorm.schema.TextSqlType
+import java.sql.Clob
+import kotlin.test.assertContentEquals
+
+class QueryTest : BaseSQLiteTest() {
+
+    @Test
+    fun testCast() {
+        val salaries = database
+            .from(Employees)
+            .select(Employees.salary.cast(TextSqlType))
+            .where { Employees.salary eq 200 }
+            .map { row ->
+                when(val value = row.getObject(1)) {
+                    is Clob -> value.characterStream.use { it.readText() }
+                    else -> value
+                }
+            }
+
+        assertContentEquals(listOf("200"), salaries)
+    }
+}

--- a/ktorm-support-sqlserver/src/test/kotlin/org/ktorm/support/sqlserver/QueryTest.kt
+++ b/ktorm-support-sqlserver/src/test/kotlin/org/ktorm/support/sqlserver/QueryTest.kt
@@ -1,0 +1,20 @@
+package org.ktorm.support.sqlserver
+
+import org.junit.Test
+import org.ktorm.dsl.*
+import org.ktorm.schema.FloatSqlType
+import kotlin.test.assertContentEquals
+
+class QueryTest : BaseSqlServerTest() {
+
+    @Test
+    fun testCast() {
+        val salaries = database
+            .from(Employees)
+            .select(Employees.salary.cast(FloatSqlType))
+            .where { Employees.salary eq 200 }
+            .map { it.getObject(1) }
+
+        assertContentEquals(listOf(200.0), salaries)
+    }
+}


### PR DESCRIPTION
Hi,
I realized during some implementation that a cast you make is actually not applied. I fixed that by overriding `visitCasting()` in SqlFormatter. During the implementation of `visitCasting()` , I also realized that
```Kotlin
if (expr.removeBrackets) {
    visit(expr)
} else {
    write("(")
    visit(expr)
    removeLastBlank()
    write(") ")
}
```
was a very common pattern used all over the place. I took the chance and refactored it into a single method `writeExpression()` to reduce the redundancy. I hope that's fine. Otherwise, I would revert it.