### PR TITLE
support: Sqlite returning clause on `Insert` & `insertOrUpdate`

### DIFF
--- a/ktorm-support-sqlite/ktorm-support-sqlite.gradle.kts
+++ b/ktorm-support-sqlite/ktorm-support-sqlite.gradle.kts
@@ -5,6 +5,6 @@ plugins {
 
 dependencies {
     api(project(":ktorm-core"))
-    api("org.xerial:sqlite-jdbc:3.34.0")
+    api("org.xerial:sqlite-jdbc:3.39.2.0")
     testImplementation(project(":ktorm-core", configuration = "testOutput"))
 }

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/BulkInsert.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/BulkInsert.kt
@@ -16,7 +16,9 @@
 
 package org.ktorm.support.sqlite
 
+import org.ktorm.database.CachedRowSet
 import org.ktorm.database.Database
+import org.ktorm.database.asIterable
 import org.ktorm.dsl.AssignmentsBuilder
 import org.ktorm.dsl.KtormDsl
 import org.ktorm.dsl.batchInsert
@@ -41,6 +43,7 @@ import org.ktorm.schema.ColumnDeclaring
  * @property conflictColumns the index columns on which the conflict may happen.
  * @property updateAssignments the updated column assignments while key conflict exists.
  * @property where the condition whether the update assignments should be executed.
+ * @property returningColumns the returning columns.
  */
 public data class BulkInsertExpression(
     val table: TableExpression,
@@ -48,6 +51,7 @@ public data class BulkInsertExpression(
     val conflictColumns: List<ColumnExpression<*>> = emptyList(),
     val updateAssignments: List<ColumnAssignmentExpression<*>> = emptyList(),
     val where: ScalarExpression<Boolean>? = null,
+    val returningColumns: List<ColumnExpression<*>> = emptyList(),
     override val isLeafNode: Boolean = false,
     override val extraProperties: Map<String, Any> = emptyMap()
 ) : SqlExpression()
@@ -102,6 +106,169 @@ public fun <T : BaseTable<*>> Database.bulkInsert(
 }
 
 /**
+ * Bulk insert records to the table and return the specific column's values.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Employees.id) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into table (name, job, manager_id, hire_date, salary, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
+ * returning id
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the column to return
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @return the returning column's values.
+ */
+public fun <T : BaseTable<*>, C : Any> Database.bulkInsertReturning(
+    table: T, returning: Column<C>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<C?> {
+    val rowSet = bulkInsertReturningRowSet(table, listOf(returning), block)
+    return rowSet.asIterable().map { row -> returning.sqlType.getResult(row, 1) }
+}
+
+/**
+ * Bulk insert records to the table and return the specific columns' values.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into table (name, job, manager_id, hire_date, salary, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.bulkInsertReturning(
+    table: T, returning: Pair<Column<C1>, Column<C2>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<Pair<C1?, C2?>> {
+    val (c1, c2) = returning
+    val rowSet = bulkInsertReturningRowSet(table, listOf(c1, c2), block)
+    return rowSet.asIterable().map { row -> Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2)) }
+}
+
+/**
+ * Bulk insert records to the table and return the specific columns' values.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     item {
+ *         set(it.name, "jerry")
+ *         set(it.job, "trainee")
+ *         set(it.managerId, 1)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 50)
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.name, "linda")
+ *         set(it.job, "assistant")
+ *         set(it.managerId, 3)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.salary, 100)
+ *         set(it.departmentId, 2)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into table (name, job, manager_id, hire_date, salary, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)...
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block, extension function of [BulkInsertStatementBuilder], used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.bulkInsertReturning(
+    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): List<Triple<C1?, C2?, C3?>> {
+    val (c1, c2, c3) = returning
+    val rowSet = bulkInsertReturningRowSet(table, listOf(c1, c2, c3), block)
+    return rowSet.asIterable().map { row ->
+        Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
+    }
+}
+
+/**
+ * Bulk insert records to the table, returning row set.
+ */
+private fun <T : BaseTable<*>> Database.bulkInsertReturningRowSet(
+    table: T, returning: List<Column<*>>, block: BulkInsertStatementBuilder<T>.(T) -> Unit
+): CachedRowSet {
+    val builder = BulkInsertStatementBuilder(table).apply { block(table) }
+
+    val expression = BulkInsertExpression(
+        table = table.asExpression(),
+        assignments = builder.assignments,
+        returningColumns = returning.map { it.asExpression() }
+    )
+
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+    return rowSet
+}
+
+/**
  * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
  * and automatically performs updates if any conflict exists.
  *
@@ -147,17 +314,182 @@ public fun <T : BaseTable<*>> Database.bulkInsertOrUpdate(
     table: T, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
 ): Int {
     val expression = AliasRemover.visit(
-        buildBulkInsertOrUpdateExpression(table, block = block)
+        buildBulkInsertOrUpdateExpression(table, returning = emptyList(), block = block)
     )
 
     return executeUpdate(expression)
 }
 
 /**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * automatically performs updates if any conflict exists, and finally returns the specific column.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Employees.id) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the column to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning column's values.
+ */
+public fun <T : BaseTable<*>, C : Any> Database.bulkInsertOrUpdateReturning(
+    table: T, returning: Column<C>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<C?> {
+    val expression = buildBulkInsertOrUpdateExpression(table, listOf(returning), block)
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+    return rowSet.asIterable().map { row -> returning.sqlType.getResult(row, 1) }
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * automatically performs updates if any conflict exists, and finally returns the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.bulkInsertOrUpdateReturning(
+    table: T, returning: Pair<Column<C1>, Column<C2>>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<Pair<C1?, C2?>> {
+    val (c1, c2) = returning
+    val expression = buildBulkInsertOrUpdateExpression(table, listOf(c1, c2), block)
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+    return rowSet.asIterable().map { row -> Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2)) }
+}
+
+/**
+ * Bulk insert records to the table, determining if there is a key conflict while inserting each of them,
+ * automatically performs updates if any conflict exists, and finally returns the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * database.bulkInsertOrUpdateReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     item {
+ *         set(it.id, 1)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     item {
+ *         set(it.id, 5)
+ *         set(it.name, "vince")
+ *         set(it.job, "engineer")
+ *         set(it.salary, 1000)
+ *         set(it.hireDate, LocalDate.now())
+ *         set(it.departmentId, 1)
+ *     }
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.bulkInsertOrUpdateReturning(
+    table: T,
+    returning: Triple<Column<C1>, Column<C2>, Column<C3>>,
+    block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+): List<Triple<C1?, C2?, C3?>> {
+    val (c1, c2, c3) = returning
+    val expression = buildBulkInsertOrUpdateExpression(table, listOf(c1, c2, c3), block)
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+    return rowSet.asIterable().map { row ->
+        Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
+    }
+}
+
+/**
  * Build a bulk insert or update expression.
  */
 private fun <T : BaseTable<*>> buildBulkInsertOrUpdateExpression(
-    table: T, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
+    table: T, returning: List<Column<*>>, block: BulkInsertOrUpdateStatementBuilder<T>.(T) -> Unit
 ): BulkInsertExpression {
     val builder = BulkInsertOrUpdateStatementBuilder(table).apply { block(table) }
 
@@ -181,7 +513,8 @@ private fun <T : BaseTable<*>> buildBulkInsertOrUpdateExpression(
         assignments = builder.assignments,
         conflictColumns = conflictColumns.map { it.asExpression() },
         updateAssignments = if (builder.doNothing) emptyList() else builder.updateAssignments,
-        where = builder.where?.asExpression()
+        where = builder.where?.asExpression(),
+        returningColumns = returning.map { it.asExpression() }
     )
 }
 

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/InsertOrUpdate.kt
@@ -16,6 +16,7 @@
 
 package org.ktorm.support.sqlite
 
+import org.ktorm.database.CachedRowSet
 import org.ktorm.database.Database
 import org.ktorm.dsl.AssignmentsBuilder
 import org.ktorm.dsl.KtormDsl
@@ -33,6 +34,7 @@ import org.ktorm.schema.ColumnDeclaring
  * @property conflictColumns the index columns on which the conflict may happen.
  * @property updateAssignments the updated column assignments while any key conflict exists.
  * @property where the condition whether the update assignments should be executed.
+ * @property returningColumns the returning columns.
  */
 public data class InsertOrUpdateExpression(
     val table: TableExpression,
@@ -40,6 +42,7 @@ public data class InsertOrUpdateExpression(
     val conflictColumns: List<ColumnExpression<*>> = emptyList(),
     val updateAssignments: List<ColumnAssignmentExpression<*>> = emptyList(),
     val where: ScalarExpression<Boolean>? = null,
+    val returningColumns: List<ColumnExpression<*>> = emptyList(),
     override val isLeafNode: Boolean = false,
     override val extraProperties: Map<String, Any> = emptyMap()
 ) : SqlExpression()
@@ -79,15 +82,179 @@ public data class InsertOrUpdateExpression(
 public fun <T : BaseTable<*>> Database.insertOrUpdate(
     table: T, block: InsertOrUpdateStatementBuilder.(T) -> Unit
 ): Int {
-    val expression = AliasRemover.visit(buildInsertOrUpdateExpression(table, block = block))
+    val expression = AliasRemover.visit(buildInsertOrUpdateExpression(table, returning = emptyList(), block = block))
     return executeUpdate(expression)
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, automatically
+ * performs an update if any conflict exists, and finally returns the specific column.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val id = database.insertOrUpdateReturning(Employees, Employees.id) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the column to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning column's value.
+ */
+public fun <T : BaseTable<*>, C : Any> Database.insertOrUpdateReturning(
+    table: T, returning: Column<C>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): C? {
+    val row = insertOrUpdateReturningRow(table, listOf(returning), block)
+    if (row == null) {
+        return null
+    } else {
+        return returning.sqlType.getResult(row, 1)
+    }
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, automatically
+ * performs an update if any conflict exists, and finally returns the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val (id, job) = database.insertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.insertOrUpdateReturning(
+    table: T, returning: Pair<Column<C1>, Column<C2>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): Pair<C1?, C2?> {
+    val (c1, c2) = returning
+    val row = insertOrUpdateReturningRow(table, listOf(c1, c2), block)
+    if (row == null) {
+        return Pair(null, null)
+    } else {
+        return Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2))
+    }
+}
+
+/**
+ * Insert a record to the table, determining if there is a key conflict while it's being inserted, automatically
+ * performs an update if any conflict exists, and finally returns the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val (id, job, salary) =
+ * database.insertOrUpdateReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ *     onConflict {
+ *         set(it.salary, it.salary + 900)
+ *     }
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * on conflict (id) do update set salary = t_employee.salary + ?
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.insertOrUpdateReturning(
+    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): Triple<C1?, C2?, C3?> {
+    val (c1, c2, c3) = returning
+    val row = insertOrUpdateReturningRow(table, listOf(c1, c2, c3), block)
+    if (row == null) {
+        return Triple(null, null, null)
+    } else {
+        return Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
+    }
+}
+
+/**
+ * Insert or update, returning one row.
+ */
+private fun <T : BaseTable<*>> Database.insertOrUpdateReturningRow(
+    table: T, returning: List<Column<*>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+): CachedRowSet? {
+    val expression = buildInsertOrUpdateExpression(table, returning, block)
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+
+    if (rowSet.size() == 0) {
+        // Possible when using onConflict { doNothing() }
+        return null
+    }
+
+    if (rowSet.size() == 1) {
+        check(rowSet.next())
+        return rowSet
+    } else {
+        val (sql, _) = formatExpression(expression, beautifySql = true)
+        throw IllegalStateException("Expected 1 row but ${rowSet.size()} returned from sql: \n\n$sql")
+    }
 }
 
 /**
  * Build an insert or update expression.
  */
 private fun <T : BaseTable<*>> buildInsertOrUpdateExpression(
-    table: T, block: InsertOrUpdateStatementBuilder.(T) -> Unit
+    table: T, returning: List<Column<*>>, block: InsertOrUpdateStatementBuilder.(T) -> Unit
 ): InsertOrUpdateExpression {
     val builder = InsertOrUpdateStatementBuilder().apply { block(table) }
 
@@ -111,8 +278,148 @@ private fun <T : BaseTable<*>> buildInsertOrUpdateExpression(
         assignments = builder.assignments,
         conflictColumns = conflictColumns.map { it.asExpression() },
         updateAssignments = if (builder.doNothing) emptyList() else builder.updateAssignments,
-        where = builder.where?.asExpression()
+        where = builder.where?.asExpression(),
+        returningColumns = returning.map { it.asExpression() }
     )
+}
+
+/**
+ * Insert a record to the table and return the specific column.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val id = database.insertReturning(Employees, Employees.id) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * returning id
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the column to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning column's value.
+ */
+public fun <T : BaseTable<*>, C : Any> Database.insertReturning(
+    table: T, returning: Column<C>, block: AssignmentsBuilder.(T) -> Unit
+): C? {
+    val row = insertReturningRow(table, listOf(returning), block)
+    return returning.sqlType.getResult(row, 1)
+}
+
+/**
+ * Insert a record to the table and return the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val (id, job) = database.insertReturning(Employees, Pair(Employees.id, Employees.job)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * returning id, job
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any> Database.insertReturning(
+    table: T, returning: Pair<Column<C1>, Column<C2>>, block: AssignmentsBuilder.(T) -> Unit
+): Pair<C1?, C2?> {
+    val (c1, c2) = returning
+    val row = insertReturningRow(table, listOf(c1, c2), block)
+    return Pair(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2))
+}
+
+/**
+ * Insert a record to the table and return the specific columns.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val (id, job, salary) =
+ * database.insertReturning(Employees, Triple(Employees.id, Employees.job, Employees.salary)) {
+ *     set(it.id, 1)
+ *     set(it.name, "vince")
+ *     set(it.job, "engineer")
+ *     set(it.salary, 1000)
+ *     set(it.hireDate, LocalDate.now())
+ *     set(it.departmentId, 1)
+ * }
+ * ```
+ *
+ * Generated SQL:
+ *
+ * ```sql
+ * insert into t_employee (id, name, job, salary, hire_date, department_id)
+ * values (?, ?, ?, ?, ?, ?)
+ * returning id, job, salary
+ * ```
+ *
+ * @since 3.4.0
+ * @param table the table to be inserted.
+ * @param returning the columns to return
+ * @param block the DSL block used to construct the expression.
+ * @return the returning columns' values.
+ */
+public fun <T : BaseTable<*>, C1 : Any, C2 : Any, C3 : Any> Database.insertReturning(
+    table: T, returning: Triple<Column<C1>, Column<C2>, Column<C3>>, block: AssignmentsBuilder.(T) -> Unit
+): Triple<C1?, C2?, C3?> {
+    val (c1, c2, c3) = returning
+    val row = insertReturningRow(table, listOf(c1, c2, c3), block)
+    return Triple(c1.sqlType.getResult(row, 1), c2.sqlType.getResult(row, 2), c3.sqlType.getResult(row, 3))
+}
+
+/**
+ * Insert and returning one row.
+ */
+private fun <T : BaseTable<*>> Database.insertReturningRow(
+    table: T, returning: List<Column<*>>, block: AssignmentsBuilder.(T) -> Unit
+): CachedRowSet {
+    val builder = SQLiteAssignmentsBuilder().apply { block(table) }
+
+    val expression = InsertOrUpdateExpression(
+        table = table.asExpression(),
+        assignments = builder.assignments,
+        returningColumns = returning.map { it.asExpression() }
+    )
+
+    val (_, rowSet) = executeUpdateAndRetrieveKeys(expression)
+
+    if (rowSet.size() == 1) {
+        check(rowSet.next())
+        return rowSet
+    } else {
+        val (sql, _) = formatExpression(expression, beautifySql = true)
+        throw IllegalStateException("Expected 1 row but ${rowSet.size()} returned from sql: \n\n$sql")
+    }
 }
 
 /**

--- a/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
+++ b/ktorm-support-sqlite/src/main/kotlin/org/ktorm/support/sqlite/SQLiteDialect.kt
@@ -103,6 +103,16 @@ public open class SQLiteFormatter(
             }
         }
 
+        if (expr.returningColumns.isNotEmpty()) {
+            writeKeyword("returning ")
+
+            for ((i, column) in expr.returningColumns.withIndex()) {
+                if (i > 0) write(", ")
+                checkColumnName(column.name)
+                write(column.name.quoted)
+            }
+        }
+
         return expr
     }
 
@@ -137,6 +147,16 @@ public open class SQLiteFormatter(
             }
         }
 
+        if (expr.returningColumns.isNotEmpty()) {
+            writeKeyword("returning ")
+
+            for ((i, column) in expr.returningColumns.withIndex()) {
+                if (i > 0) write(", ")
+                checkColumnName(column.name)
+                write(column.name.quoted)
+            }
+        }
+
         return expr
     }
 }
@@ -162,6 +182,7 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
         val conflictColumns = visitExpressionList(expr.conflictColumns)
         val updateAssignments = visitColumnAssignments(expr.updateAssignments)
         val where = expr.where?.let { visitScalar(it) }
+        val returningColumns = visitExpressionList(expr.returningColumns)
 
         @Suppress("ComplexCondition")
         if (table === expr.table
@@ -169,6 +190,7 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
             && conflictColumns === expr.conflictColumns
             && updateAssignments === expr.updateAssignments
             && where === expr.where
+            && returningColumns === expr.returningColumns
         ) {
             return expr
         } else {
@@ -177,7 +199,8 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
                 assignments = assignments,
                 conflictColumns = conflictColumns,
                 updateAssignments = updateAssignments,
-                where = where
+                where = where,
+                returningColumns = returningColumns
             )
         }
     }
@@ -188,6 +211,7 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
         val conflictColumns = visitExpressionList(expr.conflictColumns)
         val updateAssignments = visitColumnAssignments(expr.updateAssignments)
         val where = expr.where?.let { visitScalar(it) }
+        val returningColumns = visitExpressionList(expr.returningColumns)
 
         @Suppress("ComplexCondition")
         if (table === expr.table
@@ -195,6 +219,7 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
             && conflictColumns === expr.conflictColumns
             && updateAssignments === expr.updateAssignments
             && where === expr.where
+            && returningColumns === expr.returningColumns
         ) {
             return expr
         } else {
@@ -203,7 +228,8 @@ public open class SQLiteExpressionVisitor : SqlExpressionVisitor() {
                 assignments = assignments,
                 conflictColumns = conflictColumns,
                 updateAssignments = updateAssignments,
-                where = where
+                where = where,
+                returningColumns = returningColumns
             )
         }
     }

--- a/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/DmlTest.kt
+++ b/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/DmlTest.kt
@@ -1,10 +1,7 @@
 package org.ktorm.support.sqlite
 
 import org.junit.Test
-import org.ktorm.dsl.eq
-import org.ktorm.dsl.less
-import org.ktorm.dsl.plus
-import org.ktorm.dsl.update
+import org.ktorm.dsl.*
 import org.ktorm.entity.count
 import org.ktorm.entity.find
 import java.time.LocalDate
@@ -516,4 +513,19 @@ class DmlTest : BaseSQLiteTest() {
         }
     }
 
+    @Test
+    fun testInsertAndGenerateKey() {
+        val id = database.insertAndGenerateKey(Employees) {
+            set(it.name, "Joe Friend")
+            set(it.job, "Tester")
+            set(it.managerId, null)
+            set(it.salary, 50)
+            set(it.hireDate, LocalDate.of(2020, 1, 10))
+            set(it.departmentId, 1)
+        } as Int
+
+        assert(id > 4)
+
+        assert(database.employees.count() == 5)
+    }
 }

--- a/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/DmlTest.kt
+++ b/ktorm-support-sqlite/src/test/kotlin/org/ktorm/support/sqlite/DmlTest.kt
@@ -4,11 +4,31 @@ import org.junit.Test
 import org.ktorm.dsl.eq
 import org.ktorm.dsl.less
 import org.ktorm.dsl.plus
+import org.ktorm.dsl.update
 import org.ktorm.entity.count
 import org.ktorm.entity.find
 import java.time.LocalDate
 
 class DmlTest : BaseSQLiteTest() {
+
+    @Test
+    fun testUpdate() {
+        database.update(Employees) {
+            set(it.job, "engineer")
+            set(it.managerId, null)
+            set(it.salary, 100)
+
+            where {
+                it.id eq 2
+            }
+        }
+
+        val employee = database.employees.find { it.id eq 2 } ?: throw AssertionError()
+        assert(employee.name == "marry")
+        assert(employee.job == "engineer")
+        assert(employee.manager == null)
+        assert(employee.salary == 100L)
+    }
 
     @Test
     fun testInsertOrUpdate() {
@@ -37,6 +57,69 @@ class DmlTest : BaseSQLiteTest() {
 
         assert(database.employees.find { it.id eq 1 }!!.salary == 1100L)
         assert(database.employees.find { it.id eq 5 }!!.salary == 1000L)
+    }
+
+    @Test
+    fun testInsertOrUpdateReturning() {
+        database.insertOrUpdateReturning(Employees, Employees.id) {
+            set(it.name, "pedro")
+            set(it.job, "engineer")
+            set(it.salary, 1500)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+            onConflict {
+                set(it.salary, it.salary + 900)
+            }
+        }.let { id ->
+            assert(id == 5)
+        }
+
+        database.insertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+            onConflict {
+                set(it.salary, it.salary + 900)
+            }
+        }.let { (id, job) ->
+            assert(id == 6)
+            assert(job == "engineer")
+        }
+
+        val t = Employees.aliased("t")
+        database.insertOrUpdateReturning(t, Triple(t.id, t.job, t.salary)) {
+            set(it.id, 6)
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+            onConflict(it.id) {
+                set(it.salary, it.salary + 900)
+            }
+        }.let { (id, job, salary) ->
+            assert(id == 6)
+            assert(job == "engineer")
+            assert(salary == 1900L)
+        }
+
+        database.insertOrUpdateReturning(t, Triple(t.id, t.job, t.salary)) {
+            set(it.id, 6)
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+            onConflict(it.id) {
+                doNothing()
+            }
+        }.let { (id, job, salary) ->
+            assert(id == null)
+            assert(job == null)
+            assert(salary == null)
+        }
     }
 
     @Test
@@ -104,6 +187,43 @@ class DmlTest : BaseSQLiteTest() {
     }
 
     @Test
+    fun testInsertReturning() {
+        database.insertReturning(Employees, Employees.id) {
+            set(it.name, "pedro")
+            set(it.job, "engineer")
+            set(it.salary, 1500)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+        }.let { id ->
+            assert(id == 5)
+        }
+
+        database.insertReturning(Employees, Pair(Employees.id, Employees.job)) {
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+        }.let { (id, job) ->
+            assert(id == 6)
+            assert(job == "engineer")
+        }
+
+        val t = Employees.aliased("t")
+        database.insertReturning(t, Triple(t.id, t.job, t.salary)) {
+            set(it.name, "vince")
+            set(it.job, "engineer")
+            set(it.salary, 1000)
+            set(it.hireDate, LocalDate.now())
+            set(it.departmentId, 1)
+        }.let { (id, job, salary) ->
+            assert(id == 7)
+            assert(job == "engineer")
+            assert(salary == 1000L)
+        }
+    }
+
+    @Test
     fun testBulkInsert() {
         database.bulkInsert(Employees.aliased("t")) {
             item {
@@ -123,6 +243,70 @@ class DmlTest : BaseSQLiteTest() {
         }
 
         assert(database.employees.count() == 6)
+    }
+
+    @Test
+    fun testBulkInsertReturning() {
+        database.bulkInsertReturning(Employees, Employees.id) {
+            item {
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+        }.let { results ->
+            assert(results.size == 2)
+            assert(results == listOf(5, 6))
+        }
+
+        database.bulkInsertReturning(Employees, Pair(Employees.id, Employees.job)) {
+            item {
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+        }.let { results ->
+            assert(results.size == 2)
+            assert(results == listOf(Pair(7, "trainee"), Pair(8, "engineer")))
+        }
+
+        val t = Employees.aliased("t")
+        database.bulkInsertReturning(t, Triple(t.id, t.job, t.salary)) {
+            item {
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+        }.let { results ->
+            assert(results.size == 2)
+            assert(results == listOf(Triple(9, "trainee", 1000L), Triple(10, "engineer", 1000L)))
+        }
     }
 
     @Test
@@ -233,4 +417,103 @@ class DmlTest : BaseSQLiteTest() {
         assert(database.employees.find { it.id eq 5 }!!.salary == 1900L)
         assert(database.employees.find { it.id eq 6 }!!.salary == 1900L)
     }
+
+    @Test
+    fun testBulkInsertOrUpdateReturning() {
+        database.bulkInsertOrUpdateReturning(Employees, Employees.id) {
+            item {
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            onConflict {
+                doNothing()
+            }
+        }.let { results ->
+            assert(results.size == 2)
+            assert(results == listOf(5, 6))
+        }
+
+        database.bulkInsertOrUpdateReturning(Employees, Pair(Employees.id, Employees.job)) {
+            item {
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            onConflict {
+                doNothing()
+            }
+        }.let { results ->
+            assert(results.size == 2)
+            assert(results == listOf(Pair(7, "trainee"), Pair(8, "engineer")))
+        }
+
+        val t = Employees.aliased("t")
+        database.bulkInsertOrUpdateReturning(t, Triple(t.id, t.job, t.salary)) {
+            item {
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            onConflict {
+                doNothing()
+            }
+        }.let { results ->
+            assert(results.size == 2)
+            assert(results == listOf(Triple(9, "trainee", 1000L), Triple(10, "engineer", 1000L)))
+        }
+
+        database.bulkInsertOrUpdateReturning(t, Triple(t.id, t.job, t.salary)) {
+            item {
+                set(it.id, 10)
+                set(it.name, "vince")
+                set(it.job, "trainee")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            item {
+                set(it.id, 11)
+                set(it.name, "vince")
+                set(it.job, "engineer")
+                set(it.salary, 1000)
+                set(it.hireDate, LocalDate.now())
+                set(it.departmentId, 2)
+            }
+            onConflict {
+                doNothing()
+            }
+        }.let { results ->
+            assert(results.size == 1)
+            assert(results == listOf(Triple(11, "engineer", 1000L)))
+        }
+    }
+
 }


### PR DESCRIPTION
主要针对 50459d92e3a889d80c4384b9e1f08ff1c36c97c0

对于 executeUpdateAndRetrieveKeys 改为调用 executeQuery 可能需要讨论

对于 buildBulkInsertOrUpdateExpression 方法 给返回值加上 AliasRemover 可能需要讨论