### PR TITLE
[Feature] Add support for window functions

### DIFF
--- a/buildSrc/src/main/kotlin/ktorm.maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktorm.maven-publish.gradle.kts
@@ -146,6 +146,11 @@ publishing {
                         name.set("夜里的向日葵")
                         email.set("641571835@qq.com")
                     }
+                    developer {
+                        id.set("michaelfyc")
+                        name.set("michaelfyc")
+                        email.set("michael.fyc@outlook.com")
+                    }
                 }
             }
         }

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
@@ -570,6 +570,186 @@ public data class FunctionExpression<T : Any>(
 ) : ScalarExpression<T>()
 
 /**
+ * The enum of window function type in a [WindowExpression].
+ */
+public enum class WindowFunctionType(private val type: String) {
+    // aggregate
+    /**
+     * The min function, translated to `min(column)` in SQL.
+     */
+    MIN("min"),
+
+    /**
+     * The max function, translated to `max(column)` in SQL.
+     */
+    MAX("max"),
+
+    /**
+     * The avg function, translated to `avg(column)` in SQL.
+     */
+    AVG("avg"),
+
+    /**
+     * The sum function, translated to `sum(column)` in SQL.
+     */
+    SUM("sum"),
+
+    /**
+     * The count function, translated to `count(column)` in SQL.
+     */
+    COUNT("count"),
+
+    // non-aggregate
+
+    /**
+     * The cume_dist function, translated to `cume_dist()` in SQL.
+     */
+    CUME_DIST("cume_dist"),
+
+    /**
+     * The dense_rank function, translated to `dense_rank()` in SQL.
+     */
+    DENSE_RANK("dense_rank"),
+
+    /**
+     * The first_value function, translated to `first_value(column)` in SQL.
+     */
+    FIRST_VALUE("first_value"),
+
+    /**
+     * The lag function, translated to `lag(column, offset, default_value)` in SQL.
+     */
+    LAG("lag"),
+
+    /**
+     * The last_value function, translated to `last_value(column)` in SQL.
+     */
+    LAST_VALUE("last_value"),
+
+    /**
+     * The lead function, translated to `lead(column, offset, default_value)` in SQL.
+     */
+    LEAD("lead"),
+
+    /**
+     * The nth_value function, translated to `nth_value(column, n)` in SQL.
+     */
+    NTH_VALUE("nth_value"),
+
+    /**
+     * The ntile function, translated to `ntile(n)` in SQL.
+     */
+    NTILE("ntile"),
+
+    /**
+     * The percent_rank function, translated to `percent_rank()` in SQL.
+     */
+    PERCENT_RANK("percent_rank"),
+
+    /**
+     * The rank function, translated to `rank()` in SQL.
+     */
+    RANK("rank"),
+
+    /**
+     * The row_number function, translated to `row_number()` in SQL.
+     */
+    ROW_NUMBER("row_number");
+
+    override fun toString(): String {
+        return type
+    }
+}
+
+
+/**
+ * Window function expression, represents a SQL window function call.
+ *
+ * @property functionName the name of the window function.
+ * @property arguments the argument passed to the window function.
+ * @property window  window specification of the window function.
+ * @since 3.6
+ */
+public data class WindowFunctionExpression<T : Any>(
+    val functionName: WindowFunctionType,
+    val arguments: List<ScalarExpression<*>>,
+    val window: WindowExpression?,
+    override val sqlType: SqlType<T>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : ScalarExpression<T>()
+
+/**
+ * Window expression, represents either an anonymous or named window.
+ *
+ *  @property partitionArguments column expression passed to the partition clause.
+ *  @property orderByExpressions column expression passed to the orderBy clause.
+ *  @property frameUnit frame unit of a window frame clause
+ *  @property frameExpression frame clause of the window function.
+ *
+ *  @since 3.6
+ */
+public data class WindowExpression(
+    val partitionArguments: List<ScalarExpression<*>>,
+    val orderByExpressions: List<OrderByExpression>,
+    val frameUnit:FrameUnitType?,
+    val frameExpression: Pair<FrameExpression<*>,FrameExpression<*>?>?,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+): SqlExpression()
+
+/**
+ * The enum type of frame unit in [WindowExpression].
+ *
+ * @since 3.6
+ */
+public enum class FrameUnitType(private val type: String){
+    ROWS("rows"),
+    RANGE("range"),
+    GROUPS("groups"),
+    ROWS_BETWEEN("rows between"),
+    RANGE_BETWEEN("range between"),
+    GROUPS_BETWEEN("groups between");
+
+    override fun toString(): String {
+        return type
+    }
+}
+
+/**
+ * The enum type of frame extent type in [FrameExpression].
+ *
+ * @since 3.6
+ */
+public enum class FrameExtentType(private val type: String) {
+    CURRENT_ROW("current row"),
+    UNBOUNDED_PRECEDING("unbounded preceding"),
+    UNBOUNDED_FOLLOWING("unbounded following"),
+    PRECEDING("preceding"),
+    FOLLOWING("following");
+
+    override fun toString(): String {
+        return type
+    }
+}
+
+/**
+ * Frame expression, represents a SQL window function frame clause.
+ *
+ * @property frameExtentType frame extent type of a frame clause.
+ * @property argument frame argument passed to frame clause.
+ *
+ * @since 3.6
+ */
+public data class FrameExpression<T : Any>(
+    val frameExtentType: FrameExtentType,
+    val argument: ScalarExpression<*>?,
+    override val sqlType: SqlType<T>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : ScalarExpression<T>()
+
+/**
  * Case-when expression, represents a SQL case-when clause.
  *
  * There are two kind of case-when clauses in SQL, one is simple case-when clause, which has an operand following

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -537,6 +537,49 @@ public abstract class SqlFormatter(
         return expr
     }
 
+    override fun visitWindow(expr: WindowExpression): WindowExpression{
+        if (expr.partitionArguments.isNotEmpty()) {
+            writeKeyword("partition by ")
+            visitExpressionList(expr.partitionArguments)
+        }
+
+        if (expr.orderByExpressions.isNotEmpty()) {
+            writeKeyword("order by ")
+            visitOrderByList(expr.orderByExpressions)
+        }
+        if (expr.frameUnit != null) {
+            writeKeyword("${expr.frameUnit} ")
+            if (expr.frameExpression != null) {
+                val first = expr.frameExpression.first
+                val second = expr.frameExpression.second
+                first.argument?.let { visit(it) }
+                writeKeyword("${first.frameExtentType} ")
+                if(second!=null){
+                    writeKeyword("and ")
+                    second.argument?.let { visit(it) }
+                    writeKeyword("${second.frameExtentType}")
+                }
+            }
+        }
+        removeLastBlank()
+        return expr
+    }
+
+    override fun <T : Any> visitWindowFunction(expr: WindowFunctionExpression<T>): WindowFunctionExpression<T> {
+        writeKeyword("${expr.functionName}(")
+        visitExpressionList(expr.arguments)
+        removeLastBlank()
+        writeKeyword(") over (")
+        check(expr.window != null) {
+            throw DialectFeatureNotSupportedException("no anonymous or named windows found in window function expression `${expr.functionName}`.")
+        }
+
+        visitWindow(expr.window)
+
+        write(")")
+        return expr
+    }
+
     override fun <T : Any> visitCaseWhen(expr: CaseWhenExpression<T>): CaseWhenExpression<T> {
         writeKeyword("case ")
 

--- a/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/WindowFunctions.kt
+++ b/ktorm-support-mysql/src/main/kotlin/org/ktorm/support/mysql/WindowFunctions.kt
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ktorm.support.mysql
+
+import org.ktorm.expression.AggregateExpression
+import org.ktorm.expression.ArgumentExpression
+import org.ktorm.expression.FrameExpression
+import org.ktorm.expression.FrameExtentType
+import org.ktorm.expression.FrameUnitType
+import org.ktorm.expression.OrderByExpression
+import org.ktorm.expression.WindowExpression
+import org.ktorm.expression.WindowFunctionExpression
+import org.ktorm.expression.WindowFunctionType
+import org.ktorm.schema.ColumnDeclaring
+import org.ktorm.schema.SqlType
+
+/**
+ * since 3.6.0
+ * Window functions are available since MySQL 5.7
+ * reference: https://dev.mysql.com/doc/refman/8.0/en/window-functions.html
+ *
+ */
+
+
+/**
+ * Most MySQL aggregate functions also can be used as window functions.
+ */
+public infix fun <T : Any> AggregateExpression<T>.over(window: WindowExpression): WindowFunctionExpression<T> {
+    val arguments = if (this.argument != null) {
+        listOf(this.argument!!)
+    } else {
+        emptyList()
+    }
+    return WindowFunctionExpression(
+        WindowFunctionType.valueOf(this.type.name),
+        arguments,
+        window,
+        this.sqlType
+    )
+}
+
+public infix fun <T : Any> WindowFunctionExpression<T>.over(window: WindowExpression): WindowFunctionExpression<T> {
+    return WindowFunctionExpression(
+        functionName,
+        arguments,
+        window,
+        this.sqlType
+    )
+}
+
+public fun partitionBy(vararg columns: ColumnDeclaring<*>): WindowExpression {
+    return WindowExpression(
+        partitionArguments = columns.map { it.asExpression() },
+        orderByExpressions = emptyList(),
+        frameUnit = null,
+        frameExpression = null,
+    )
+}
+
+public fun orderBy(vararg orderByExpression: OrderByExpression): WindowExpression {
+    return WindowExpression(
+        partitionArguments = emptyList(),
+        orderByExpressions = orderByExpression.asList(),
+        frameUnit = null,
+        frameExpression = null,
+    )
+}
+
+
+public fun WindowExpression.orderBy(vararg orderByExpression: OrderByExpression): WindowExpression {
+    return WindowExpression(
+        partitionArguments,
+        orderByExpression.asList(),
+        null,
+        null
+    )
+}
+
+public fun Int.preceding(): FrameExpression<Int> {
+    return FrameExpression(
+        frameExtentType = FrameExtentType.PRECEDING,
+        argument = ArgumentExpression(
+            value = this,
+            sqlType = SqlType.of()!!
+        ),
+        sqlType = SqlType.of()!!
+    )
+}
+
+public fun Int.following(): FrameExpression<Int> {
+    return FrameExpression(
+        frameExtentType = FrameExtentType.FOLLOWING,
+        argument = ArgumentExpression(
+            value = this,
+            sqlType = SqlType.of()!!
+        ),
+        sqlType = SqlType.of()!!
+    )
+}
+
+/**
+ * Translated to MySQL reserved keyword `UNBOUNDED PRECEDING`.
+ */
+public val UNBOUNDED_PRECEDING: FrameExpression<Int> = FrameExpression(
+    frameExtentType = FrameExtentType.UNBOUNDED_PRECEDING,
+    argument = null,
+    sqlType = SqlType.of()!!
+)
+
+/**
+ * Translated to MySQL reserved keyword `UNBOUNDED FOLLOWING`.
+ */
+public val UNBOUNDED_FOLLOWING: FrameExpression<Int> = FrameExpression(
+    frameExtentType = FrameExtentType.UNBOUNDED_FOLLOWING,
+    argument = null,
+    sqlType = SqlType.of()!!
+)
+
+/**
+ * Translated to MySQL reserved key word `CURRENT ROW`.
+ */
+public val CURRENT_ROW: FrameExpression<Int> = FrameExpression(
+    frameExtentType = FrameExtentType.CURRENT_ROW,
+    argument = null,
+    sqlType = SqlType.of()!!
+)
+
+/**
+ * Translated to MySQL frame unit `rows between`.
+ */
+public fun <A : Any, B : Any> WindowExpression.rowsBetween(
+    left: FrameExpression<A>,
+    right: FrameExpression<B>
+): WindowExpression {
+    return WindowExpression(
+        partitionArguments,
+        orderByExpressions,
+        FrameUnitType.ROWS_BETWEEN,
+        Pair(left, right)
+    )
+}
+
+/**
+ * Translated to MySQL frame unit `range between`.
+ */
+public fun <A : Any, B : Any> WindowExpression.rangeBetween(
+    left: FrameExpression<A>,
+    right: FrameExpression<B>
+): WindowExpression {
+    return WindowExpression(
+        partitionArguments,
+        orderByExpressions,
+        FrameUnitType.RANGE_BETWEEN,
+        Pair(left, right)
+    )
+}
+
+/**
+ * Translated to MySQL frame unit `range`.
+ */
+public fun <T : Any> WindowExpression.range(
+    frameExpression: FrameExpression<T>,
+): WindowExpression {
+    return WindowExpression(
+        partitionArguments,
+        orderByExpressions,
+        FrameUnitType.RANGE,
+        Pair(frameExpression, null)
+    )
+}
+
+/**
+ * Translated to MySQL frame unit `rows`.
+ */
+public fun <T : Any> WindowExpression.row(
+    frameExpression: FrameExpression<T>,
+): WindowExpression {
+    return WindowExpression(
+        partitionArguments,
+        orderByExpressions,
+        FrameUnitType.ROWS,
+        Pair(frameExpression, null)
+    )
+}
+
+/**
+ * MySQL rank window function, translated to `rank()`.
+ */
+public fun rank(): WindowFunctionExpression<Int> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.RANK,
+        arguments = emptyList(),
+        window = null,
+        sqlType = SqlType.of()!!
+    )
+}
+
+/**
+ * MySQL row_number window function, translated to `row_number()`.
+ */
+public fun rowNumber(): WindowFunctionExpression<Int> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.ROW_NUMBER,
+        arguments = emptyList(),
+        window = null,
+        sqlType = SqlType.of()!!
+    )
+}
+
+/**
+ * MySQL dense_rank window function, translated to `dense_rank()`.
+ */
+public fun denseRank(): WindowFunctionExpression<Int> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.DENSE_RANK,
+        arguments = emptyList(),
+        window = null,
+        sqlType = SqlType.of()!!
+    )
+}
+
+
+/**
+ * MySQL percent_rank window function, translated to `percent_rank()`.
+ */
+public fun percentRank(): WindowFunctionExpression<Double> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.PERCENT_RANK,
+        arguments = emptyList(),
+        window = null,
+        sqlType = SqlType.of()!!
+    )
+}
+
+/**
+ * MySQL cume_dist window function, translated to `cume_dist()`.
+ */
+public fun cumeDist(): WindowFunctionExpression<Int> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.CUME_DIST,
+        arguments = emptyList(),
+        window = null,
+        sqlType = SqlType.of()!!
+    )
+}
+
+/**
+ * MySQL first_value window function, translated to `first_value(column)`.
+ */
+public fun <T : Any> firstValue(column: ColumnDeclaring<T>): WindowFunctionExpression<T> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.FIRST_VALUE,
+        arguments = listOf(column.asExpression()),
+        window = null,
+        sqlType = column.sqlType
+    )
+}
+
+/**
+ * MySQL last_value window function, translated to `last_value(column)`.
+ */
+public fun <T : Any> lastValue(column: ColumnDeclaring<T>): WindowFunctionExpression<T> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.LAST_VALUE,
+        arguments = listOf(column.asExpression()),
+        window = null,
+        sqlType = column.sqlType
+    )
+}
+
+/**
+ * MySQL ntile window function, translated to `ntile(n)`.
+ */
+public fun ntile(n: Int): WindowFunctionExpression<Int> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.NTILE,
+        arguments = listOf(
+            ArgumentExpression(
+                n,
+                SqlType.of() ?: error("Cannot detect the param's SqlType, please specify manually.")
+            )
+        ),
+        window = null,
+        sqlType = SqlType.of()!!
+    )
+}
+
+/**
+ * MySQL nth_value window function, translated to `nth_value(column, n)`.
+ */
+public fun <T : Any> nthValue(column: ColumnDeclaring<T>, n: Int): WindowFunctionExpression<T> {
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.NTH_VALUE,
+        arguments = listOf(
+            column.asExpression(),
+            ArgumentExpression(n, SqlType.of() ?: error("Cannot detect the param's SqlType, please specify manually."))
+        ),
+        window = null,
+        sqlType = column.sqlType
+    )
+}
+
+/**
+ * MySQL lead window function, translated to `lead(column, offset, <defaultValue>)`.
+ */
+public fun <T : Any> lead(
+    column: ColumnDeclaring<T>,
+    offset: Int,
+    defaultValue: Int? = null
+): WindowFunctionExpression<T> {
+    val arguments = mutableListOf(
+        column.asExpression(),
+        ArgumentExpression(offset, SqlType.of() ?: error("Cannot detect the param's SqlType, please specify manually."))
+    )
+    if (defaultValue != null) {
+        arguments.add(
+            ArgumentExpression(
+                defaultValue,
+                SqlType.of() ?: error("Cannot detect the param's SqlType, please specify manually.")
+            )
+        )
+    }
+
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.LEAD,
+        arguments = arguments,
+        window = null,
+        sqlType = column.sqlType
+    )
+}
+
+/**
+ * MySQL lag window function, translated to `lag(column, offset, <defaultValue>)`.
+ */
+public fun <T : Any> lag(
+    column: ColumnDeclaring<T>,
+    offset: Int,
+    defaultValue: Int? = null
+): WindowFunctionExpression<T> {
+    val arguments = mutableListOf(
+        column.asExpression(),
+        ArgumentExpression(offset, SqlType.of() ?: error("Cannot detect the param's SqlType, please specify manually."))
+    )
+    if (defaultValue != null) {
+        arguments.add(
+            ArgumentExpression(
+                defaultValue,
+                SqlType.of() ?: error("Cannot detect the param's SqlType, please specify manually.")
+            )
+        )
+    }
+
+    return WindowFunctionExpression(
+        functionName = WindowFunctionType.LAG,
+        arguments = arguments,
+        window = null,
+        sqlType = column.sqlType
+    )
+}
+


### PR DESCRIPTION
ANSI SQL2003 allows for a window_clause in aggregate function calls, the addition of which makes those functions into window functions. Nowadays, many mainstream relational databases, including MySQL, SQLite, Postgres, have supported window functions syntax. However, it is still rare to see an ORM framework that supports it. Ktorm, as a lightweight but powerful ORM framework, has the ability to be a pioneer.
**This pull request mainly focuses on implementing window function expression for MySQL dialect.** 