### PR TITLE
Make Database#exceptionTranslator return a nullable throwable.

### DIFF
--- a/ktorm-core/src/main/kotlin/org/ktorm/database/Database.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/database/Database.kt
@@ -118,7 +118,7 @@ public class Database(
     /**
      * Function used to translate SQL exceptions to rethrow them to users.
      */
-    public val exceptionTranslator: ((SQLException) -> Throwable)? = null,
+    public val exceptionTranslator: ((SQLException) -> Throwable?)? = null,
 
     /**
      * Whether we need to always quote SQL identifiers in the generated SQLs.


### PR DESCRIPTION
o.s.jdbc.support.AbstractFallbackSQLExceptionTranslator#translate has been allowed nullable return value in new version

See:https://github.com/spring-projects/spring-framework/commit/e9cded560d6ecb73aa5bfca57e06b09fa0013294