### PR TITLE
Track and Provide Access to Changed Properties

### DIFF
--- a/buildSrc/src/main/kotlin/ktorm.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktorm.publish.gradle.kts
@@ -163,6 +163,25 @@ publishing {
                 }
             }
         }
+
+        repositories {
+            maven {
+                name = "central"
+                url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+                credentials {
+                    username = System.getenv("OSSRH_USER")
+                    password = System.getenv("OSSRH_PASSWORD")
+                }
+            }
+            maven {
+                name = "snapshot"
+                url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+                credentials {
+                    username = System.getenv("OSSRH_USER")
+                    password = System.getenv("OSSRH_PASSWORD")
+                }
+            }
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/ktorm.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktorm.publish.gradle.kts
@@ -155,25 +155,11 @@ publishing {
                         id.set("brohacz")
                         name.set("Michal Brosig")
                     }
-                }
-            }
-        }
-
-        repositories {
-            maven {
-                name = "central"
-                url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
-                credentials {
-                    username = System.getenv("OSSRH_USER")
-                    password = System.getenv("OSSRH_PASSWORD")
-                }
-            }
-            maven {
-                name = "snapshot"
-                url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-                credentials {
-                    username = System.getenv("OSSRH_USER")
-                    password = System.getenv("OSSRH_PASSWORD")
+                    developer {
+                        id.set("hc224")
+                        name.set("hc224")
+                        email.set("hc224@pm.me")
+                    }
                 }
             }
         }

--- a/ktorm-core/src/main/kotlin/org/ktorm/entity/Entity.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/entity/Entity.kt
@@ -144,6 +144,14 @@ public interface Entity<E : Entity<E>> : Serializable {
     public val properties: Map<String, Any?>
 
     /**
+     * Return the immutable view of the original values for this entity's changed properties.
+     *
+     * Properties are set as changed when constructing an entity with non-default values or when setting a property.
+     * If the property is set to the same value it is still marked as changed.
+     */
+    public val changedProperties: Map<String, Any?>
+
+    /**
      * Update the property changes of this entity into the database and return the affected record number.
      *
      * Using this function, we need to note that:

--- a/ktorm-core/src/main/kotlin/org/ktorm/entity/EntityImplementation.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/entity/EntityImplementation.kt
@@ -38,7 +38,7 @@ internal class EntityImplementation(
     @Transient var fromDatabase: Database? = fromDatabase
     @Transient var fromTable: Table<*>? = fromTable
     @Transient var parent: EntityImplementation? = parent
-    @Transient var changedProperties = LinkedHashSet<String>()
+    @Transient var changedProperties = LinkedHashMap<String, Any?>()
 
     override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
         return when (method.declaringClass.kotlin) {
@@ -54,6 +54,7 @@ internal class EntityImplementation(
                 when (method.name) {
                     "getEntityClass" -> this.entityClass
                     "getProperties" -> Collections.unmodifiableMap(this.values)
+                    "getChangedProperties" -> Collections.unmodifiableMap(this.changedProperties)
                     "flushChanges" -> this.doFlushChanges()
                     "discardChanges" -> this.doDiscardChanges()
                     "delete" -> this.doDelete()
@@ -150,13 +151,15 @@ internal class EntityImplementation(
             throw UnsupportedOperationException(msg)
         }
 
+        // Map#putIfAbsent treats null as absent, but null is a valid entity value
+        if (!changedProperties.containsKey(name))
+            changedProperties[name] = this.values.getOrDefault(name, null)
         values[name] = value
-        changedProperties.add(name)
     }
 
     private fun copy(): Entity<*> {
         val entity = Entity.create(entityClass, parent, fromDatabase, fromTable)
-        entity.implementation.changedProperties.addAll(changedProperties)
+        entity.implementation.changedProperties.putAll(changedProperties)
 
         for ((name, value) in values) {
             if (value is Entity<*>) {
@@ -204,7 +207,7 @@ internal class EntityImplementation(
         val javaClass = Class.forName(input.readUTF(), true, Thread.currentThread().contextClassLoader)
         entityClass = javaClass.kotlin
         values = input.readObject() as LinkedHashMap<String, Any?>
-        changedProperties = LinkedHashSet()
+        changedProperties = LinkedHashMap()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/ktorm-core/src/test/kotlin/org/ktorm/entity/EntityTest.kt
+++ b/ktorm-core/src/test/kotlin/org/ktorm/entity/EntityTest.kt
@@ -48,6 +48,50 @@ class EntityTest : BaseTest() {
     }
 
     @Test
+    fun testEntityChangedPropertiesInitializer() {
+        val employee = Employee { name = "walter" }
+        println(employee)
+
+        assert(employee.changedProperties.size == 1)
+        assert(employee.changedProperties.contains("name"))
+        assert(employee.changedProperties["name"] == null)
+    }
+
+    @Test
+    fun testEntityChangedPropertiesSetter() {
+        val employee = Employee { }
+        println(employee)
+
+        val oldChangedPropertiesIsEmpty = employee.changedProperties.isEmpty()
+
+        employee.name = "walter"
+        println(employee)
+
+        assert(oldChangedPropertiesIsEmpty)
+        assert(employee.changedProperties.size == 1)
+        assert(employee.changedProperties.contains("name"))
+        assert(employee.changedProperties["name"] == null)
+    }
+
+    @Test
+    fun testEntityChangedPropertiesMultiple() {
+        val employee = Employee { }.copy()
+        println(employee)
+
+        val oldChangedPropertiesIsEmpty = employee.changedProperties.isEmpty()
+
+        employee.name = "walter"
+        println(employee)
+        employee.name = "vince"
+        println(employee)
+
+        assert(oldChangedPropertiesIsEmpty)
+        assert(employee.changedProperties.size == 1)
+        assert(employee.changedProperties.containsKey("name"))
+        assert(employee.changedProperties["name"] == null)
+    }
+
+    @Test
     fun testDefaultMethod() {
         for (method in Employee::class.java.methods) {
             println(method)


### PR DESCRIPTION
Tracks an entities changed properties and the values loaded from SQL.

I needed this to implement an auditing system like #135 seems to be asking for, but how that should work varies and there is not a single solution. These changes should provide what is needed for users to implement this system themselves.

I used these changes locally and was able to create an auditing system that tracks entity values changed by ktorm.