### PR TITLE
Fixed a binary compatibility error when using a higher version of KotlinModule

### DIFF
--- a/ktorm-jackson/src/main/kotlin/org/ktorm/jackson/JsonSqlType.kt
+++ b/ktorm-jackson/src/main/kotlin/org/ktorm/jackson/JsonSqlType.kt
@@ -19,7 +19,7 @@ package org.ktorm.jackson
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import org.ktorm.schema.*
 import java.lang.reflect.InvocationTargetException
 import java.sql.PreparedStatement
@@ -31,7 +31,7 @@ import java.sql.Types
  */
 public val sharedObjectMapper: ObjectMapper = ObjectMapper()
     .registerModule(KtormModule())
-    .registerModule(KotlinModule())
+    .registerModule(kotlinModule())
     .registerModule(JavaTimeModule())
 
 /**


### PR DESCRIPTION
Since `2.11`, `KotlinModule` recommends initialization with `Builder`.
If initialization is done by primary constructor calls with default arguments, subsequent option additions will cause problems such as #526.

In local verification, this resolved #526.