### PR TITLE
fix: reduce memory allocation on Column.label used for accessing in query

### DIFF
--- a/ktorm-core/src/main/kotlin/org/ktorm/schema/Column.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/schema/Column.kt
@@ -118,7 +118,7 @@ public data class Column<T : Any>(
      *
      * @see ColumnDeclaringExpression
      */
-    val label: String get() = toString(separator = "_")
+    val label: String by lazy { toString(separator = "_") }
 
     /**
      * Return all the bindings of this column, including the primary [binding] and [extraBindings].


### PR DESCRIPTION
Given the simple example as provided in the documentation provided (see https://www.ktorm.org/en/query.html)

```kt
val query = database.from(Employees).select()

query
    .map { row -> Emp(row[Employees.id], row[Employees.name], row[Employees.salary]) }
```

this will actually generate a label per row per column in order to access the element in the table via call stack of:

```kt
QueryRowSet.get(Column)
Column.getLabel()
Column.toString("_")
```

however, this getter initializes a string on every instance, so if you have 1000 rows, this will generate 1000 strings x the number of columns that are all the same for every call.

### Alternative approaches

- Initialize the string when initializing the Column itself (not using lazy)
- Use lazy with a different synchronization mode

As always, thanks for reading and maintaining the library!